### PR TITLE
feat(cli): add ensemble personhood check command

### DIFF
--- a/IDENTITY-TOKEN.md
+++ b/IDENTITY-TOKEN.md
@@ -78,8 +78,8 @@ const tokenAddress = await clanker.deployToken({
   },
   rewardsConfig: {
     creatorReward: 80,
-    creatorAdmin: "0x703ae03fB120eC91e9Ed6d08Ce8044E498CC789B",
-    creatorRewardRecipient: "0x703ae03fB120eC91e9Ed6d08Ce8044E498CC789B",
+    creatorAdmin: "0xeb0ABB367540f90B57b3d5719fd2b9c740a15022",
+    creatorRewardRecipient: "0xeb0ABB367540f90B57b3d5719fd2b9c740a15022",
   },
 });
 ```

--- a/README.md
+++ b/README.md
@@ -13,13 +13,19 @@ A 14-day online hackathon where AI agents and humans build together as equals.
 | **Email** | m@oakgroup.co |
 | **Social** | @estmcmxci |
 | **API Key** | Set `SYNTH_API_KEY` env var |
-| **Wallet** | `0x6ffa1e00509d8b625c2f061d7db07893b37199bc` |
+| **Platform Registrar** | `0x6ffa1e00509d8b625c2f061d7db07893b37199bc` (owns all hackathon ERC-8004 tokens) |
 | **Token ID** | 24994 (0x61a2) — Synthesis hackathon registration |
 | **ERC-8004 Contract** | `0x8004a169fb4a3325136eb29fa0ceb6d2e539a432` (Base mainnet) |
 | **Registration TX** | [BaseScan](https://basescan.org/tx/0x4760c23310e4d8f74e0d432e1dda2256d93b1429e5c92de380d023a6968d2853) |
+| **Signing Address** | `0xeb0ABB367540f90B57b3d5719fd2b9c740a15022` (manager of emilemarcelagustin.eth) |
 
-> **Note:** There are two ERC-8004 registrations for estmcmxci.eth:
-> - **#24994** — registered for the Synthesis hackathon (this project)
+> **Note on addresses:**
+> - `0x6ffa...9bc` is the **hackathon platform's registrar** — it minted 762+ ERC-8004 tokens on behalf of participants. We do not hold the private key.
+> - `0xeb0A...022` is the **signing address** we control — manager of emilemarcelagustin.eth. Used for ENS record-setting, manifest signing, and AgentBook registration.
+> - `0x703a...89B` (estmcmxci.eth owner) holds personal assets and is **not used** for project operations.
+>
+> There are two ERC-8004 registrations:
+> - **#24994** — registered by the hackathon platform (this project)
 > - **#19327** — registered earlier for the Bankr agent identity integration
 >
 > Both are on Base mainnet at the same registry contract. This project uses **#24994**.

--- a/packages/cli/commands/index.ts
+++ b/packages/cli/commands/index.ts
@@ -16,3 +16,4 @@ export { nameContract } from "./name";
 export { renew } from "./renew";
 export { transfer } from "./transfer";
 export { registerAgent, linkAgent, agentInfo } from "./agent";
+export { personhoodCheck } from "./personhood";

--- a/packages/cli/commands/personhood.ts
+++ b/packages/cli/commands/personhood.ts
@@ -1,0 +1,63 @@
+/**
+ * Personhood Commands
+ *
+ * World ID AgentBook lookups — proof-of-personhood verification.
+ */
+
+import colors from "yoctocolors";
+import { isAddress } from "viem";
+import { resolvePersonhood } from "@synthesis/resolver";
+import { startSpinner, stopSpinner } from "../utils/spinner";
+
+export interface PersonhoodCheckOptions {
+  address: string;
+  network?: string;
+}
+
+/**
+ * Check if an address is backed by a verified human in AgentBook.
+ */
+export async function personhoodCheck(options: PersonhoodCheckOptions) {
+  const { address, network } = options;
+
+  if (!isAddress(address)) {
+    console.error(colors.red(`Invalid address: ${address}`));
+    return;
+  }
+
+  const networks =
+    network === "world"
+      ? (["world"] as const)
+      : network === "base-sepolia"
+        ? (["base-sepolia"] as const)
+        : (["base", "world"] as const);
+
+  startSpinner(`Checking personhood for ${colors.cyan(address)}...`);
+
+  const result = await resolvePersonhood(address, { networks: [...networks] });
+
+  stopSpinner();
+
+  if (result.verified) {
+    console.log(
+      colors.green("✓") + colors.bold(" Personhood: verified"),
+    );
+    console.log(`  Nullifier: ${colors.cyan(result.nullifierHash!)}`);
+    console.log(`  Network:   ${result.network}`);
+    console.log(`  Contract:  ${result.agentBookAddress}`);
+  } else {
+    console.log(
+      colors.red("✗") + colors.bold(" Personhood: not registered"),
+    );
+    console.log(
+      colors.dim(
+        "  This address is not registered in AgentBook on any checked network.",
+      ),
+    );
+    console.log(
+      colors.dim(
+        "  Use `ensemble personhood register` to register via World ID.",
+      ),
+    );
+  }
+}

--- a/packages/cli/index.ts
+++ b/packages/cli/index.ts
@@ -28,6 +28,7 @@ import {
 	registerAgent,
 	linkAgent,
 	agentInfo,
+	personhoodCheck,
 } from "./commands";
 import { stopSpinner } from "./utils/spinner";
 
@@ -614,6 +615,49 @@ agent.command("info", {
 });
 
 cli.command(agent);
+
+// =============================================================================
+// Personhood Subcommand Group (World ID + AgentBook)
+// =============================================================================
+
+const personhood = Cli.create("personhood", {
+	description: "World ID proof-of-personhood verification",
+});
+
+personhood.command("check", {
+	description:
+		"Check if an address is backed by a verified human in AgentBook",
+	args: z.object({
+		address: z.string().describe("Ethereum address to check"),
+	}),
+	options: z.object({
+		network: z
+			.string()
+			.optional()
+			.describe("AgentBook network: base (default), world, base-sepolia"),
+	}),
+	alias: { network: "n" },
+	examples: [
+		{
+			args: { address: "0xeb0ABB367540f90B57b3d5719fd2b9c740a15022" },
+			description: "Check personhood on Base + World Chain",
+		},
+		{
+			args: { address: "0xeb0ABB367540f90B57b3d5719fd2b9c740a15022" },
+			options: { network: "world" },
+			description: "Check only on World Chain",
+		},
+	],
+	async run({ args, options }) {
+		await personhoodCheck({
+			address: args.address,
+			network: options.network,
+		});
+		return { checked: args.address };
+	},
+});
+
+cli.command(personhood);
 
 // =============================================================================
 // Serve

--- a/plans/phase-0-personhood.md
+++ b/plans/phase-0-personhood.md
@@ -111,11 +111,15 @@ This handles the full World ID QR code flow (displays QR → user scans with Wor
 
 **What**: Actually run the registration for our agent wallet.
 
-**Address to register**: `0x703ae03fB120eC91e9Ed6d08Ce8044E498CC789B` (estmcmxci.eth owner)
+**Address to register**: `0xeb0ABB367540f90B57b3d5719fd2b9c740a15022` (manager of emilemarcelagustin.eth)
+
+> **Security note**: We use the emilemarcelagustin.eth manager address, NOT the estmcmxci.eth
+> owner (`0x703a...89B`) which holds personal assets. Private key for `0xeb0A...022` is stored
+> in `.env` as `ENS_PRIVATE_KEY`.
 
 **This is a human task** — requires biometric World ID verification via the Orb or World App. Can be done after SYN-47 is built by running:
 ```bash
-ensemble personhood register --address 0x703ae03fB120eC91e9Ed6d08Ce8044E498CC789B --network base
+ensemble personhood register --address 0xeb0ABB367540f90B57b3d5719fd2b9c740a15022 --network base
 ```
 
 ## PRD Update Required


### PR DESCRIPTION
## Summary
- Add `ensemble personhood check <address>` CLI command
- Queries AgentBook contracts on Base + World Chain for World ID verification
- Uses `@synthesis/resolver`'s `resolvePersonhood()` under the hood
- Update project docs to use signing address `0xeb0A...022` (manager of emilemarcelagustin.eth) instead of personal wallet

Closes SYN-13

## Test plan
- [x] `ensemble personhood check 0xeb0ABB...022` returns "not registered" (expected — registration pending)
- [x] `ensemble personhood --help` shows check subcommand
- [x] Invalid address shows error message
- [ ] Will return "verified" after SYN-14 AgentBook registration

🤖 Generated with [Claude Code](https://claude.com/claude-code)