### PR TITLE
feat(cli): add ensemble personhood register command

### DIFF
--- a/packages/cli/commands/index.ts
+++ b/packages/cli/commands/index.ts
@@ -16,4 +16,4 @@ export { nameContract } from "./name";
 export { renew } from "./renew";
 export { transfer } from "./transfer";
 export { registerAgent, linkAgent, agentInfo } from "./agent";
-export { personhoodCheck } from "./personhood";
+export { personhoodCheck, personhoodRegister } from "./personhood";

--- a/packages/cli/commands/personhood.ts
+++ b/packages/cli/commands/personhood.ts
@@ -1,9 +1,10 @@
 /**
  * Personhood Commands
  *
- * World ID AgentBook lookups — proof-of-personhood verification.
+ * World ID AgentBook lookups and registration — proof-of-personhood verification.
  */
 
+import { execFileSync } from "node:child_process";
 import colors from "yoctocolors";
 import { isAddress } from "viem";
 import { resolvePersonhood } from "@synthesis/resolver";
@@ -12,6 +13,12 @@ import { startSpinner, stopSpinner } from "../utils/spinner";
 export interface PersonhoodCheckOptions {
   address: string;
   network?: string;
+}
+
+export interface PersonhoodRegisterOptions {
+  address: string;
+  network?: string;
+  manual?: boolean;
 }
 
 /**
@@ -59,5 +66,60 @@ export async function personhoodCheck(options: PersonhoodCheckOptions) {
         "  Use `ensemble personhood register` to register via World ID.",
       ),
     );
+  }
+}
+
+/**
+ * Register an address in AgentBook via World ID verification.
+ *
+ * Shells out to @worldcoin/agentkit-cli which handles the full
+ * QR code flow (display QR → user scans with World App → ZK proof → on-chain registration).
+ */
+export async function personhoodRegister(options: PersonhoodRegisterOptions) {
+  const { address, network = "base", manual } = options;
+
+  if (!isAddress(address)) {
+    console.error(colors.red(`Invalid address: ${address}`));
+    return;
+  }
+
+  console.log(colors.bold("World ID AgentBook Registration"));
+  console.log(`  Address:  ${colors.cyan(address)}`);
+  console.log(`  Network:  ${network}`);
+  console.log();
+  console.log(
+    colors.yellow(
+      "This will open a World ID verification flow. You'll need to scan a QR code with the World App.",
+    ),
+  );
+  console.log();
+
+  const args = ["@worldcoin/agentkit-cli", "register", address, "--network", network];
+
+  if (manual) {
+    args.push("--manual");
+    console.log(colors.dim("Manual mode — will print calldata instead of submitting via relay."));
+    console.log();
+  }
+
+  try {
+    execFileSync("npx", args, {
+      stdio: "inherit",
+      env: { ...process.env },
+    });
+
+    console.log();
+    console.log(colors.green("✓") + colors.bold(" Registration submitted."));
+    console.log(
+      colors.dim("  Run `ensemble personhood check " + address + "` to verify."),
+    );
+  } catch (error) {
+    console.log();
+    console.error(
+      colors.red("✗") + " Registration failed or was cancelled.",
+    );
+    if (error instanceof Error && "status" in error) {
+      console.error(colors.dim(`  Exit code: ${(error as NodeJS.ErrnoException & { status: number }).status}`));
+    }
   }
 }

--- a/packages/cli/index.ts
+++ b/packages/cli/index.ts
@@ -29,6 +29,7 @@ import {
 	linkAgent,
 	agentInfo,
 	personhoodCheck,
+	personhoodRegister,
 } from "./commands";
 import { stopSpinner } from "./utils/spinner";
 
@@ -654,6 +655,46 @@ personhood.command("check", {
 			network: options.network,
 		});
 		return { checked: args.address };
+	},
+});
+
+personhood.command("register", {
+	description:
+		"Register an address in AgentBook via World ID verification",
+	args: z.object({
+		address: z
+			.string()
+			.describe("Address to register (defaults to ENS_PRIVATE_KEY signer)"),
+	}),
+	options: z.object({
+		network: z
+			.string()
+			.optional()
+			.describe("Target network: base (default), world, base-sepolia"),
+		manual: z
+			.boolean()
+			.optional()
+			.describe("Print calldata instead of submitting via relay"),
+	}),
+	alias: { network: "n", manual: "m" },
+	examples: [
+		{
+			args: { address: "0xeb0ABB367540f90B57b3d5719fd2b9c740a15022" },
+			description: "Register on Base mainnet via relay",
+		},
+		{
+			args: { address: "0xeb0ABB367540f90B57b3d5719fd2b9c740a15022" },
+			options: { manual: true },
+			description: "Print calldata for manual submission",
+		},
+	],
+	async run({ args, options }) {
+		await personhoodRegister({
+			address: args.address,
+			network: options.network,
+			manual: options.manual,
+		});
+		return { registered: args.address };
 	},
 });
 


### PR DESCRIPTION
## Summary
- Add `ensemble personhood register <address>` CLI command
- Shells out to `@worldcoin/agentkit-cli` for World ID QR code verification flow
- Supports `--network` (base/world/base-sepolia) and `--manual` (print calldata) flags
- Inherits stdio so the QR code renders directly in the terminal

Closes SYN-47

## Test plan
- [x] `ensemble personhood --help` shows both `check` and `register` subcommands
- [x] `ensemble personhood register --help` shows correct args/options
- [ ] Full registration flow tested with World App (SYN-14)

🤖 Generated with [Claude Code](https://claude.com/claude-code)