### PR TITLE
feat(resolver): implement manifest layer — AIP V2 Mode A

### DIFF
--- a/packages/resolver/src/index.ts
+++ b/packages/resolver/src/index.ts
@@ -10,9 +10,14 @@ export {
   AgentBookNetwork,
   PersonhoodResultSchema,
   IdentityResultSchema,
+  AgentManifestSchema,
+  AgentManifestSignatureSchema,
+  ManifestResultSchema,
   type TrustProfile,
   type PersonhoodResult,
   type IdentityResult,
+  type AgentManifest,
+  type ManifestResult,
 } from "./schema.js";
 
 export {
@@ -24,6 +29,11 @@ export {
   resolveIdentity,
   type ResolveIdentityOptions,
 } from "./layers/identity.js";
+
+export {
+  resolveManifest,
+  type ResolveManifestOptions,
+} from "./layers/manifest.js";
 
 export {
   createEnsClient,

--- a/packages/resolver/src/layers/manifest.ts
+++ b/packages/resolver/src/layers/manifest.ts
@@ -1,0 +1,235 @@
+/**
+ * Resolution Layer 3: Integrity (AIP — Agent Identity Profile)
+ *
+ * Implements the AIP V2 spec (Mode A — subname-per-version):
+ * 1. Read agent-latest + agent-version-lineage from root name
+ * 2. Resolve agent-manifest from version subname (e.g., v1.<root>)
+ * 3. Fetch manifest from IPFS
+ * 4. Verify signature against ENS owner
+ * 5. Walk prev chain for lineage audit
+ *
+ * Read-only: never writes records.
+ */
+
+import { verifyMessage, type PublicClient } from "viem";
+import type { AgentManifest, ManifestResult } from "../schema.js";
+import { AgentManifestSchema } from "../schema.js";
+import { createEnsClient, getTextRecord, resolveAddress } from "../utils/ens.js";
+import { extractCid, fetchFromIpfs } from "../utils/ipfs.js";
+
+export interface ResolveManifestOptions {
+  ensRpcUrl?: string;
+  maxLineageDepth?: number;
+}
+
+/**
+ * Resolve AIP manifest for an ENS name.
+ *
+ * Follows the AIP V2 client behavior (Section 3):
+ * 1. Read agent-latest and agent-version-lineage from root
+ * 2. Resolve manifestRef based on lineage mode
+ * 3. Fetch + parse manifest
+ * 4. Verify ensName, version, and signature
+ * 5. Walk prev pointers for lineage audit
+ */
+export async function resolveManifest(
+  ensName: string,
+  options: ResolveManifestOptions = {},
+): Promise<ManifestResult> {
+  const client = createEnsClient(options.ensRpcUrl);
+  const maxDepth = options.maxLineageDepth ?? 10;
+
+  // Step 1: Read root records
+  const [latestVersion, lineageMode] = await Promise.all([
+    getTextRecord(client, ensName, "agent-latest"),
+    getTextRecord(client, ensName, "agent-version-lineage"),
+  ]);
+
+  if (!latestVersion) {
+    return emptyResult();
+  }
+
+  // Step 2: Resolve manifestRef based on lineage mode
+  let manifestRef: string | null = null;
+
+  if (!lineageMode || lineageMode === "subname") {
+    // Mode A (RECOMMENDED): subname-per-version
+    const versionName = `${latestVersion}.${ensName}`;
+    manifestRef = await getTextRecord(client, versionName, "agent-manifest");
+  } else if (lineageMode.startsWith("list:")) {
+    // Mode B: parse append-only list, find entry for latest version
+    manifestRef = parseListEntry(lineageMode, latestVersion);
+  }
+
+  if (!manifestRef) {
+    return {
+      ...emptyResult(),
+      latestVersion,
+      lineageMode: lineageMode ?? "subname",
+    };
+  }
+
+  // Step 3: Fetch manifest from IPFS
+  const manifest = await fetchManifest(manifestRef);
+  if (!manifest) {
+    return {
+      ...emptyResult(),
+      latestVersion,
+      lineageMode: lineageMode ?? "subname",
+    };
+  }
+
+  // Step 4: Verify manifest
+  const signatureValid = await verifyManifestSignature(
+    client,
+    ensName,
+    latestVersion,
+    manifest,
+  );
+
+  // Step 5: Walk lineage
+  const { depth, intact } = await walkLineage(manifest, maxDepth);
+
+  return {
+    found: true,
+    latestVersion,
+    lineageMode: lineageMode ?? "subname",
+    manifest,
+    signatureValid,
+    lineageDepth: depth,
+    lineageIntact: intact,
+  };
+}
+
+/**
+ * Fetch and parse an AIP manifest from a CID/URL reference.
+ */
+async function fetchManifest(
+  manifestRef: string,
+): Promise<AgentManifest | null> {
+  const cid = extractCid(manifestRef);
+  if (!cid) return null;
+
+  const content = await fetchFromIpfs(cid);
+  if (!content) return null;
+
+  try {
+    const parsed = JSON.parse(content);
+    const result = AgentManifestSchema.safeParse(parsed);
+    return result.success ? result.data : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Verify an AIP manifest signature per AIP V2 Section 2.3.
+ *
+ * Checks:
+ * 1. ensName matches the root name being resolved
+ * 2. version matches the version identifier
+ * 3. Signature is valid against the current ENS owner
+ */
+async function verifyManifestSignature(
+  client: PublicClient,
+  ensName: string,
+  expectedVersion: string,
+  manifest: AgentManifest,
+): Promise<boolean> {
+  // Verify ensName matches
+  if (manifest.ensName !== ensName) return false;
+
+  // Verify version matches
+  if (manifest.version !== expectedVersion) return false;
+
+  // Get the current ENS owner address
+  const ownerAddress = await resolveAddress(client, ensName);
+  if (!ownerAddress) return false;
+
+  // Build canonical bytes (sorted keys, no whitespace)
+  const { signature, ...manifestWithoutSig } = manifest;
+  const canonicalBytes = JSON.stringify(manifestWithoutSig, Object.keys(manifestWithoutSig).sort());
+
+  try {
+    // Verify EIP-191 signature
+    const isValid = await verifyMessage({
+      address: ownerAddress,
+      message: canonicalBytes,
+      signature: signature.value as `0x${string}`,
+    });
+    return isValid;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Walk the prev pointer chain for lineage audit.
+ *
+ * Returns the depth (number of prev pointers traversed) and
+ * whether the chain is intact (no broken links).
+ */
+async function walkLineage(
+  manifest: AgentManifest,
+  maxDepth: number,
+): Promise<{ depth: number; intact: boolean }> {
+  let depth = 0;
+  let current = manifest.prev;
+
+  while (current && depth < maxDepth) {
+    const cid = extractCid(current);
+    if (!cid) return { depth, intact: false };
+
+    const content = await fetchFromIpfs(cid);
+    if (!content) return { depth, intact: false };
+
+    try {
+      const parsed = JSON.parse(content);
+      const result = AgentManifestSchema.safeParse(parsed);
+      if (!result.success) return { depth, intact: false };
+
+      depth++;
+      current = result.data.prev;
+    } catch {
+      return { depth, intact: false };
+    }
+  }
+
+  // If current is null, we've reached genesis — lineage is intact
+  return { depth, intact: current === null };
+}
+
+/**
+ * Parse a Mode B list entry to find the manifestRef for a version.
+ */
+function parseListEntry(
+  listValue: string,
+  version: string,
+): string | null {
+  const lines = listValue
+    .replace(/^list:/, "")
+    .split("\n")
+    .map((l) => l.trim())
+    .filter(Boolean);
+
+  for (const line of lines) {
+    const parts = line.split(/\s+/);
+    if (parts[0] === version && parts[1]) {
+      return parts[1];
+    }
+  }
+
+  return null;
+}
+
+function emptyResult(): ManifestResult {
+  return {
+    found: false,
+    latestVersion: null,
+    lineageMode: null,
+    manifest: null,
+    signatureValid: false,
+    lineageDepth: 0,
+    lineageIntact: false,
+  };
+}

--- a/packages/resolver/src/schema.ts
+++ b/packages/resolver/src/schema.ts
@@ -37,6 +37,35 @@ export const IdentityResultSchema = z.object({
 
 export type IdentityResult = z.infer<typeof IdentityResultSchema>;
 
+export const AgentManifestSignatureSchema = z.object({
+  scheme: z.string(),
+  value: z.string(),
+});
+
+export const AgentManifestSchema = z.object({
+  schema: z.string(),
+  ensName: z.string(),
+  version: z.string(),
+  prev: z.string().nullable(),
+  payload: z.record(z.unknown()),
+  manifestHash: z.string().optional(),
+  signature: AgentManifestSignatureSchema,
+});
+
+export type AgentManifest = z.infer<typeof AgentManifestSchema>;
+
+export const ManifestResultSchema = z.object({
+  found: z.boolean(),
+  latestVersion: z.string().nullable(),
+  lineageMode: z.string().nullable(),
+  manifest: AgentManifestSchema.nullable(),
+  signatureValid: z.boolean(),
+  lineageDepth: z.number(),
+  lineageIntact: z.boolean(),
+});
+
+export type ManifestResult = z.infer<typeof ManifestResultSchema>;
+
 export const TrustProfileSchema = z.object({
   name: z.string(),
   address: z.string().regex(/^0x[a-fA-F0-9]{40}$/),


### PR DESCRIPTION
## Summary
- Add `resolveManifest()` to `@synthesis/resolver` — Resolution Layer 3 (Integrity)
- Implements AIP V2 client behavior (confirmed Mode A with spec author):
  1. Read `agent-latest` + `agent-version-lineage` from root name
  2. Resolve `agent-manifest` from version subname (e.g., `v1.<root>`)
  3. Fetch manifest JSON from IPFS via gateway
  4. Verify `ensName` + `version` match, EIP-191 signature against ENS owner
  5. Walk `prev` pointer chain for lineage audit
- Default-deny: unreachable/unsigned/unverifiable = UNVERIFIED
- Add `AgentManifestSchema` + `ManifestResultSchema` Zod types
- Mode B (list) parsing also supported but Mode A is primary

Closes SYN-22

## Test plan
- [x] `pnpm --filter @synthesis/resolver build` compiles cleanly
- [ ] Will return `found: true` after AIP records are set in Phase 3

🤖 Generated with [Claude Code](https://claude.com/claude-code)