### PR TITLE
feat(cli): add ensemble trust — flagship TRL resolution command

### DIFF
--- a/packages/cli/commands/index.ts
+++ b/packages/cli/commands/index.ts
@@ -17,3 +17,4 @@ export { renew } from "./renew";
 export { transfer } from "./transfer";
 export { registerAgent, linkAgent, agentInfo } from "./agent";
 export { personhoodCheck, personhoodRegister } from "./personhood";
+export { trust } from "./trust";

--- a/packages/cli/commands/trust.ts
+++ b/packages/cli/commands/trust.ts
@@ -1,0 +1,117 @@
+/**
+ * Trust Command — Full TRL Resolution
+ *
+ * The flagship command. Resolves an ENS name through all 5 trust layers
+ * and displays the result.
+ */
+
+import colors from "yoctocolors";
+import { resolve, type TrustProfile } from "@synthesis/resolver";
+import { startSpinner, stopSpinner } from "../utils/spinner";
+
+export interface TrustOptions {
+  name: string;
+  agentIds?: string[];
+}
+
+/**
+ * Run full TRL resolution on an ENS name and display results.
+ */
+export async function trust(options: TrustOptions) {
+  const { name, agentIds } = options;
+
+  startSpinner(`Resolving trust profile for ${colors.cyan(name)}...`);
+
+  const profile = await resolve(name, {
+    knownAgentIds: agentIds,
+  });
+
+  stopSpinner();
+
+  printProfile(profile);
+}
+
+function printProfile(profile: TrustProfile) {
+  console.log();
+  console.log(colors.bold(`  Trust Profile: ${colors.cyan(profile.ensName)}`));
+  console.log(colors.dim(`  Address: ${profile.address ?? "unresolved"}`));
+  console.log();
+
+  // Layer 0: Personhood
+  printLayer(
+    "Personhood",
+    profile.personhood.verified,
+    profile.personhood.verified
+      ? `World ID, nullifier: ${profile.personhood.nullifierHash?.slice(0, 10)}...`
+      : "not registered in AgentBook",
+  );
+
+  // Layer 1: Identity
+  printLayer(
+    "Identity",
+    profile.identity.verified,
+    profile.identity.verified
+      ? `ERC-8004 #${profile.identity.agentId}, ${profile.identity.registryChain}`
+      : "no ENSIP-25 registration found",
+  );
+
+  // Layer 2: Context
+  printLayer(
+    "Context",
+    profile.context.found,
+    profile.context.found
+      ? profile.context.skillUrl
+        ? `ENSIP-26, SKILL.md at ${profile.context.skillUrl}`
+        : "ENSIP-26 present (no SKILL.md URL)"
+      : "no agent-context record",
+  );
+
+  // Layer 3: Manifest
+  printLayer(
+    "Manifest",
+    profile.manifest.found && profile.manifest.signatureValid,
+    profile.manifest.found
+      ? profile.manifest.signatureValid
+        ? `AIP ${profile.manifest.latestVersion}, signature valid, lineage depth: ${profile.manifest.lineageDepth}`
+        : `AIP ${profile.manifest.latestVersion}, signature INVALID`
+      : "no AIP records found",
+  );
+
+  // Layer 4: Skill
+  printLayer(
+    "Skill",
+    profile.skill.found && profile.skill.domainVerified,
+    profile.skill.found
+      ? profile.skill.domainVerified
+        ? `domain-verified, served from ${profile.skill.url}`
+        : `found but domain NOT verified (${profile.skill.url})`
+      : "no SKILL.md found",
+  );
+
+  // Trust Tier
+  console.log();
+  const tierColor = getTierColor(profile.trustScore);
+  console.log(`  Trust Tier: ${tierColor(profile.trustScore)}`);
+  console.log();
+}
+
+function printLayer(name: string, passed: boolean, detail: string) {
+  const icon = passed ? colors.green("✓") : colors.red("✗");
+  const label = passed ? colors.bold(name) : colors.dim(name);
+  console.log(`  ${icon} ${label}: ${colors.dim(detail)}`);
+}
+
+function getTierColor(tier: string) {
+  switch (tier) {
+    case "full":
+      return colors.green;
+    case "verified":
+      return colors.cyan;
+    case "discoverable":
+      return colors.yellow;
+    case "registered":
+      return colors.magenta;
+    default:
+      return colors.red;
+  }
+}

--- a/packages/cli/index.ts
+++ b/packages/cli/index.ts
@@ -30,6 +30,7 @@ import {
 	agentInfo,
 	personhoodCheck,
 	personhoodRegister,
+	trust as trustCmd,
 } from "./commands";
 import { stopSpinner } from "./utils/spinner";
 
@@ -66,6 +67,43 @@ cli.use(async (_c, next) => {
 			// Ignore errors during cleanup
 		}
 	}
+});
+
+// =============================================================================
+// Trust Resolution
+// =============================================================================
+
+cli.command("trust", {
+	description:
+		"Resolve an ENS name through all 5 trust layers and display the trust profile",
+	args: z.object({
+		name: z.string().describe("ENS name to resolve (e.g., emilemarcelagustin.eth)"),
+	}),
+	options: z.object({
+		agentId: z
+			.array(z.string())
+			.optional()
+			.describe("Known agent IDs to scan for ENSIP-25 records (can repeat)"),
+	}),
+	alias: { agentId: "a" },
+	examples: [
+		{
+			args: { name: "emilemarcelagustin.eth" },
+			description: "Full trust resolution",
+		},
+		{
+			args: { name: "emilemarcelagustin.eth" },
+			options: { agentId: ["24994"] },
+			description: "Resolve with known agent ID",
+		},
+	],
+	async run({ args, options }) {
+		await trustCmd({
+			name: args.name,
+			agentIds: options.agentId,
+		});
+		return { resolved: args.name };
+	},
 });
 
 // =============================================================================


### PR DESCRIPTION
## Summary
- Add `ensemble trust <name>` — the headline command for Synthesis
- Resolves an ENS name through all 5 trust layers (personhood → identity → context → manifest → skill)
- Displays per-layer pass/fail with details
- Shows aggregate trust tier with color coding
- `--agentId` flag for known ENSIP-25 agent IDs

Closes SYN-25

## Test plan
- [x] `ensemble trust emilemarcelagustin.eth --agentId 24994` runs successfully
- [x] Personhood shows verified (World ID registered on Base)
- [x] Remaining layers show not found (expected — records not set until Phase 3)
- [x] Trust tier displays as `none` with red coloring

🤖 Generated with [Claude Code](https://claude.com/claude-code)