### PR TITLE
feat(cli): add ensemble manifest — create, pin, verify AIP manifests

### DIFF
--- a/packages/cli/commands/index.ts
+++ b/packages/cli/commands/index.ts
@@ -18,3 +18,4 @@ export { transfer } from "./transfer";
 export { registerAgent, linkAgent, agentInfo } from "./agent";
 export { personhoodCheck, personhoodRegister } from "./personhood";
 export { trust } from "./trust";
+export { manifestCreate, manifestPin, manifestVerify } from "./manifest";

--- a/packages/cli/commands/manifest.ts
+++ b/packages/cli/commands/manifest.ts
@@ -1,0 +1,192 @@
+/**
+ * Manifest Commands — AIP V2 Manifest Lifecycle
+ *
+ * Create, pin, and verify AIP manifests.
+ */
+
+import colors from "yoctocolors";
+import { privateKeyToAccount } from "viem/accounts";
+import { createHash } from "node:crypto";
+import { writeFileSync, readFileSync } from "node:fs";
+import {
+  resolveManifest,
+  type AgentManifest,
+} from "@synthesis/resolver";
+import { startSpinner, stopSpinner } from "../utils/spinner";
+
+export interface ManifestCreateOptions {
+  name: string;
+  version: string;
+  prev?: string;
+  payload?: string;
+  output?: string;
+}
+
+export interface ManifestPinOptions {
+  file: string;
+}
+
+export interface ManifestVerifyOptions {
+  name: string;
+  agentIds?: string[];
+}
+
+/**
+ * Create an AIP manifest, sign with ENS_PRIVATE_KEY (EIP-191).
+ */
+export async function manifestCreate(options: ManifestCreateOptions) {
+  const { name, version, prev, payload: payloadJson, output } = options;
+
+  const privateKey = process.env.ENS_PRIVATE_KEY;
+  if (!privateKey) {
+    console.error(colors.red("Error: ENS_PRIVATE_KEY not set"));
+    return;
+  }
+
+  const account = privateKeyToAccount(privateKey as `0x${string}`);
+
+  // Parse payload if provided
+  let payload: Record<string, unknown> = {};
+  if (payloadJson) {
+    try {
+      payload = JSON.parse(payloadJson);
+    } catch {
+      console.error(colors.red("Error: --payload must be valid JSON"));
+      return;
+    }
+  }
+
+  // Build manifest without signature
+  const manifestBody = {
+    schema: "ens.agent/1",
+    ensName: name,
+    version,
+    prev: prev ?? null,
+    payload,
+  };
+
+  // Canonical bytes: sorted keys, no whitespace
+  const canonicalBytes = JSON.stringify(
+    manifestBody,
+    Object.keys(manifestBody).sort(),
+  );
+
+  // Compute manifestHash
+  const hash = createHash("sha256").update(canonicalBytes).digest("hex");
+
+  // Sign with EIP-191
+  startSpinner("Signing manifest...");
+  const signature = await account.signMessage({ message: canonicalBytes });
+  stopSpinner();
+
+  const manifest: AgentManifest = {
+    ...manifestBody,
+    manifestHash: `sha256:${hash}`,
+    signature: {
+      scheme: "evm-owner-signature",
+      value: signature,
+    },
+  };
+
+  const json = JSON.stringify(manifest, null, 2);
+
+  if (output) {
+    writeFileSync(output, json);
+    console.log(colors.green("✓") + ` Manifest written to ${colors.cyan(output)}`);
+  } else {
+    console.log(json);
+  }
+
+  console.log();
+  console.log(`  ${colors.blue("Signer:")} ${account.address}`);
+  console.log(`  ${colors.blue("Hash:")} sha256:${hash}`);
+  console.log(`  ${colors.blue("Version:")} ${version}`);
+  console.log(`  ${colors.blue("Prev:")} ${prev ?? "null (genesis)"}`);
+}
+
+/**
+ * Pin a manifest JSON file to IPFS via Pinata.
+ */
+export async function manifestPin(options: ManifestPinOptions) {
+  const { file } = options;
+
+  const pinataJwt = process.env.PINATA_JWT;
+  if (!pinataJwt) {
+    console.error(colors.red("Error: PINATA_JWT not set"));
+    return;
+  }
+
+  let content: string;
+  try {
+    content = readFileSync(file, "utf-8");
+    JSON.parse(content); // validate JSON
+  } catch {
+    console.error(colors.red(`Error: cannot read or parse ${file}`));
+    return;
+  }
+
+  startSpinner("Pinning to IPFS via Pinata...");
+
+  try {
+    const { PinataSDK } = await import("pinata");
+    const pinata = new PinataSDK({ pinataJwt, pinataGateway: "" });
+    const result = await pinata.upload.public.json(JSON.parse(content));
+    stopSpinner();
+
+    console.log(colors.green("✓") + " Pinned to IPFS");
+    console.log(`  ${colors.blue("CID:")} ${result.cid}`);
+    console.log(`  ${colors.blue("URI:")} ipfs://${result.cid}`);
+    console.log(`  ${colors.blue("Gateway:")} https://gateway.pinata.cloud/ipfs/${result.cid}`);
+  } catch (error) {
+    stopSpinner();
+    console.error(colors.red(`Error pinning: ${(error as Error).message}`));
+  }
+}
+
+/**
+ * Verify an AIP manifest for an ENS name.
+ * Uses the resolver layer to fetch, verify signature, and walk lineage.
+ */
+export async function manifestVerify(options: ManifestVerifyOptions) {
+  const { name } = options;
+
+  startSpinner(`Verifying manifest for ${colors.cyan(name)}...`);
+
+  const result = await resolveManifest(name);
+
+  stopSpinner();
+
+  if (!result.found) {
+    console.log(colors.red("✗") + " No AIP manifest found");
+    console.log(colors.dim("  Set agent-latest and agent-version-lineage on the root name."));
+    return;
+  }
+
+  console.log(colors.green("✓") + ` Manifest found (${result.latestVersion})`);
+  console.log(`  ${colors.blue("Lineage mode:")} ${result.lineageMode}`);
+
+  if (result.manifest) {
+    console.log(`  ${colors.blue("Schema:")} ${result.manifest.schema}`);
+    console.log(`  ${colors.blue("ENS name:")} ${result.manifest.ensName}`);
+    console.log(`  ${colors.blue("Version:")} ${result.manifest.version}`);
+    console.log(`  ${colors.blue("Prev:")} ${result.manifest.prev ?? "null (genesis)"}`);
+    if (result.manifest.manifestHash) {
+      console.log(`  ${colors.blue("Hash:")} ${result.manifest.manifestHash}`);
+    }
+  }
+
+  // Signature
+  if (result.signatureValid) {
+    console.log(`  ${colors.green("✓")} Signature valid`);
+  } else {
+    console.log(`  ${colors.red("✗")} Signature INVALID or unverifiable`);
+  }
+
+  // Lineage
+  console.log(`  ${colors.blue("Lineage depth:")} ${result.lineageDepth}`);
+  if (result.lineageIntact) {
+    console.log(`  ${colors.green("✓")} Lineage intact`);
+  } else {
+    console.log(`  ${colors.yellow("⚠")} Lineage incomplete or broken`);
+  }
+}

--- a/packages/cli/index.ts
+++ b/packages/cli/index.ts
@@ -31,6 +31,9 @@ import {
 	personhoodCheck,
 	personhoodRegister,
 	trust as trustCmd,
+	manifestCreate,
+	manifestPin,
+	manifestVerify,
 } from "./commands";
 import { stopSpinner } from "./utils/spinner";
 
@@ -737,6 +740,81 @@ personhood.command("register", {
 });
 
 cli.command(personhood);
+
+// =============================================================================
+// Manifest Subcommand Group (AIP V2)
+// =============================================================================
+
+const manifest = Cli.create("manifest", {
+	description: "AIP manifest lifecycle — create, pin, and verify",
+});
+
+manifest.command("create", {
+	description: "Create a signed AIP manifest (EIP-191)",
+	args: z.object({
+		name: z.string().describe("ENS name for the manifest"),
+	}),
+	options: z.object({
+		ver: z.string().optional().describe("Version identifier (default: v1)"),
+		prev: z.string().optional().describe("Previous manifest CID (null for genesis)"),
+		payload: z.string().optional().describe("Payload as JSON string"),
+		output: z.string().optional().describe("Output file path (prints to stdout if omitted)"),
+	}),
+	alias: { prev: "p", payload: "d", output: "o" },
+	examples: [
+		{
+			args: { name: "emilemarcelagustin.eth" },
+			options: { version: "v1", output: "manifest-v1.json" },
+			description: "Create genesis manifest",
+		},
+	],
+	async run({ args, options }) {
+		await manifestCreate({
+			name: args.name,
+			version: options.ver ?? "v1",
+			prev: options.prev,
+			payload: options.payload,
+			output: options.output,
+		});
+		return { created: args.name };
+	},
+});
+
+manifest.command("pin", {
+	description: "Pin a manifest JSON file to IPFS via Pinata",
+	args: z.object({
+		file: z.string().describe("Path to manifest JSON file"),
+	}),
+	examples: [
+		{
+			args: { file: "manifest-v1.json" },
+			description: "Pin manifest to IPFS",
+		},
+	],
+	async run({ args }) {
+		await manifestPin({ file: args.file });
+		return { pinned: args.file };
+	},
+});
+
+manifest.command("verify", {
+	description: "Verify an AIP manifest for an ENS name",
+	args: z.object({
+		name: z.string().describe("ENS name to verify"),
+	}),
+	examples: [
+		{
+			args: { name: "emilemarcelagustin.eth" },
+			description: "Verify manifest signature and lineage",
+		},
+	],
+	async run({ args }) {
+		await manifestVerify({ name: args.name });
+		return { verified: args.name };
+	},
+});
+
+cli.command(manifest);
 
 // =============================================================================
 // Serve


### PR DESCRIPTION
## Summary
- Add `ensemble manifest` subcommand group for AIP V2 lifecycle:
  - `create <name>` — build manifest JSON, sign with EIP-191, compute sha256 hash
  - `pin <file>` — pin manifest to IPFS via Pinata SDK
  - `verify <name>` — fetch from ENS, verify signature + lineage via resolver
- Uses `--ver` flag (not `--version` which conflicts with CLI framework)

Closes SYN-44

## Test plan
- [x] `ensemble manifest --help` shows all 3 subcommands
- [x] `manifest create` produces valid signed manifest with correct signer
- [x] `manifest verify` returns "not found" (expected — records not set)
- [ ] `manifest pin` requires PINATA_JWT — will test in Phase 3

🤖 Generated with [Claude Code](https://claude.com/claude-code)