### PR TITLE
feat(cli): add ensemble context — ENSIP-26 get/set commands

### DIFF
--- a/packages/cli/commands/context.ts
+++ b/packages/cli/commands/context.ts
@@ -1,0 +1,100 @@
+/**
+ * Context Commands — ENSIP-26 agent-context
+ *
+ * Read and write the agent-context text record on an ENS name.
+ */
+
+import colors from "yoctocolors";
+import { resolveContext } from "@synthesis/resolver";
+import { startSpinner, stopSpinner } from "../utils/spinner";
+import { setTextRecordOnChain, getResolver, normalizeEnsName } from "../utils";
+
+export interface ContextGetOptions {
+  name: string;
+}
+
+export interface ContextSetOptions {
+  name: string;
+  value: string;
+  network?: string;
+  useLedger?: boolean;
+  accountIndex?: number;
+}
+
+/**
+ * Read and display the agent-context record for an ENS name.
+ */
+export async function contextGet(options: ContextGetOptions) {
+  const { name } = options;
+
+  startSpinner(`Reading agent-context for ${colors.cyan(name)}...`);
+  const result = await resolveContext(name);
+  stopSpinner();
+
+  if (!result.found) {
+    console.log(colors.red("✗") + " No agent-context record found");
+    console.log(colors.dim("  Set one with: ensemble context set <name> <json>"));
+    return;
+  }
+
+  console.log(colors.green("✓") + " agent-context found");
+
+  if (result.parsed) {
+    console.log(`  ${colors.blue("Parsed:")}`);
+    for (const [key, value] of Object.entries(result.parsed)) {
+      console.log(`    ${colors.dim(`${key}:`)} ${JSON.stringify(value)}`);
+    }
+  } else {
+    console.log(`  ${colors.blue("Raw:")} ${result.raw}`);
+  }
+
+  if (result.skillUrl) {
+    console.log(`  ${colors.blue("SKILL.md URL:")} ${colors.cyan(result.skillUrl)}`);
+  }
+}
+
+/**
+ * Set the agent-context text record on an ENS name.
+ */
+export async function contextSet(options: ContextSetOptions) {
+  const { name, value, network, useLedger, accountIndex } = options;
+
+  // Validate JSON if it looks like JSON
+  if (value.startsWith("{")) {
+    try {
+      JSON.parse(value);
+    } catch {
+      console.error(colors.red("Error: value looks like JSON but failed to parse"));
+      return;
+    }
+  }
+
+  const normalized = normalizeEnsName(name);
+  const resolverAddress = await getResolver(normalized, network);
+
+  if (!resolverAddress) {
+    console.error(colors.red(`No resolver found for ${name}`));
+    return;
+  }
+
+  startSpinner(`Setting agent-context on ${colors.cyan(name)}...`);
+
+  try {
+    await setTextRecordOnChain(
+      normalized,
+      "agent-context",
+      value,
+      resolverAddress,
+      network,
+      useLedger,
+      accountIndex ?? 0,
+    );
+    stopSpinner();
+
+    console.log(colors.green("✓") + ` agent-context set on ${colors.cyan(name)}`);
+    console.log(`  ${colors.blue("Value:")} ${value.length > 80 ? value.slice(0, 80) + "..." : value}`);
+  } catch (error) {
+    stopSpinner();
+    console.error(colors.red(`Error: ${(error as Error).message}`));
+  }
+}

--- a/packages/cli/commands/index.ts
+++ b/packages/cli/commands/index.ts
@@ -19,3 +19,4 @@ export { registerAgent, linkAgent, agentInfo } from "./agent";
 export { personhoodCheck, personhoodRegister } from "./personhood";
 export { trust } from "./trust";
 export { manifestCreate, manifestPin, manifestVerify } from "./manifest";
+export { contextGet, contextSet } from "./context";

--- a/packages/cli/index.ts
+++ b/packages/cli/index.ts
@@ -34,6 +34,8 @@ import {
 	manifestCreate,
 	manifestPin,
 	manifestVerify,
+	contextGet,
+	contextSet,
 } from "./commands";
 import { stopSpinner } from "./utils/spinner";
 
@@ -815,6 +817,66 @@ manifest.command("verify", {
 });
 
 cli.command(manifest);
+
+// =============================================================================
+// Context Subcommand Group (ENSIP-26)
+// =============================================================================
+
+const context = Cli.create("context", {
+	description: "ENSIP-26 agent-context — read and write discovery records",
+});
+
+context.command("get", {
+	description: "Read the agent-context record for an ENS name",
+	args: z.object({
+		name: z.string().describe("ENS name to query"),
+	}),
+	examples: [
+		{
+			args: { name: "emilemarcelagustin.eth" },
+			description: "Read agent-context",
+		},
+	],
+	async run({ args }) {
+		await contextGet({ name: args.name });
+		return { queried: args.name };
+	},
+});
+
+context.command("set", {
+	description: "Set the agent-context text record on an ENS name",
+	args: z.object({
+		name: z.string().describe("ENS name to update"),
+		value: z.string().describe("Context value (JSON string or plain text)"),
+	}),
+	options: z.object({
+		network: z.string().optional().describe("Network to use (mainnet, sepolia)"),
+		ledger: z.boolean().optional().describe("Use Ledger hardware wallet"),
+		accountIndex: z.string().optional().describe("Ledger account index (default: 0)"),
+	}),
+	alias: { network: "n", ledger: "l" },
+	examples: [
+		{
+			args: {
+				name: "emilemarcelagustin.eth",
+				value: '{"skill":"https://emilemarcelagustin.eth.limo/skill.md"}',
+			},
+			description: "Set agent-context with SKILL.md URL",
+		},
+	],
+	async run({ args, options }) {
+		await contextSet({
+			name: args.name,
+			value: args.value,
+			network: options.network,
+			useLedger: options.ledger,
+			accountIndex: options.accountIndex ? parseInt(options.accountIndex, 10) : 0,
+		});
+		return { set: args.name };
+	},
+});
+
+cli.command(context);
 
 // =============================================================================
 // Serve


### PR DESCRIPTION
## Summary
- Add `ensemble context` subcommand group for ENSIP-26 agent-context
- `context get <name>` — read + parse agent-context, display SKILL.md URL if found
- `context set <name> <value>` — write agent-context text record on-chain

Closes SYN-45

## Test plan
- [x] `ensemble context --help` shows get/set subcommands
- [x] `context get emilemarcelagustin.eth` returns "not found" (expected)
- [ ] `context set` will be tested in Phase 3 when setting records

🤖 Generated with [Claude Code](https://claude.com/claude-code)