### PR TITLE
feat(cli): add ensemble skill — SKILL.md fetch + domain verification

### DIFF
--- a/packages/cli/commands/index.ts
+++ b/packages/cli/commands/index.ts
@@ -20,3 +20,4 @@ export { personhoodCheck, personhoodRegister } from "./personhood";
 export { trust } from "./trust";
 export { manifestCreate, manifestPin, manifestVerify } from "./manifest";
 export { contextGet, contextSet } from "./context";
+export { skillFetch } from "./skill";

--- a/packages/cli/commands/skill.ts
+++ b/packages/cli/commands/skill.ts
@@ -1,0 +1,55 @@
+/**
+ * Skill Commands — DVS / SKILL.md fetch + domain verification
+ *
+ * Fetch a SKILL.md from a URL and verify domain ownership against an ENS name.
+ */
+
+import colors from "yoctocolors";
+import { resolveSkill } from "@synthesis/resolver";
+import { startSpinner, stopSpinner } from "../utils/spinner";
+
+export interface SkillFetchOptions {
+  name: string;
+  url: string;
+}
+
+/**
+ * Fetch a SKILL.md and verify domain ownership against an ENS name.
+ */
+export async function skillFetch(options: SkillFetchOptions) {
+  const { name, url } = options;
+
+  startSpinner(`Fetching SKILL.md from ${colors.cyan(url)}...`);
+  const result = await resolveSkill(name, url);
+  stopSpinner();
+
+  if (!result.found) {
+    console.log(colors.red("✗") + " SKILL.md not found or unreachable");
+    console.log(colors.dim(`  URL: ${url}`));
+    return;
+  }
+
+  console.log(colors.green("✓") + " SKILL.md fetched");
+  console.log(`  ${colors.blue("URL:")} ${result.url}`);
+  console.log(`  ${colors.blue("Size:")} ${result.content?.length ?? 0} bytes`);
+
+  if (result.domainVerified) {
+    console.log(`  ${colors.green("✓")} Domain verified for ${colors.cyan(name)}`);
+  } else {
+    console.log(`  ${colors.red("✗")} Domain NOT verified for ${name}`);
+    console.log(colors.dim("  The serving domain doesn't match the ENS name."));
+  }
+
+  // Show preview of content
+  if (result.content) {
+    const preview = result.content.slice(0, 500);
+    console.log();
+    console.log(colors.blue("  Preview:"));
+    for (const line of preview.split("\n").slice(0, 15)) {
+      console.log(`  ${colors.dim(line)}`);
+    }
+    if (result.content.length > 500) {
+      console.log(colors.dim(`  ... (${result.content.length - 500} more bytes)`));
+    }
+  }
+}

--- a/packages/cli/index.ts
+++ b/packages/cli/index.ts
@@ -36,6 +36,7 @@ import {
 	manifestVerify,
 	contextGet,
 	contextSet,
+	skillFetch,
 } from "./commands";
 import { stopSpinner } from "./utils/spinner";
 
@@ -877,6 +878,31 @@ context.command("set", {
 });
 
 cli.command(context);
+
+// =============================================================================
+// Skill Command (DVS)
+// =============================================================================
+
+cli.command("skill", {
+	description: "Fetch a SKILL.md and verify domain ownership against an ENS name",
+	args: z.object({
+		name: z.string().describe("ENS name to verify against"),
+		url: z.string().describe("URL or IPFS URI of the SKILL.md"),
+	}),
+	examples: [
+		{
+			args: {
+				name: "emilemarcelagustin.eth",
+				url: "https://emilemarcelagustin.eth.limo/skill.md",
+			},
+			description: "Fetch and verify SKILL.md",
+		},
+	],
+	async run({ args }) {
+		await skillFetch({ name: args.name, url: args.url });
+		return { fetched: args.url };
+	},
+});
 
 // =============================================================================
 // Serve


### PR DESCRIPTION
## Summary
- Add `ensemble skill <name> <url>` command for DVS
- Fetches SKILL.md from URL or IPFS URI
- Verifies serving domain matches the ENS name
- Shows content preview (first 15 lines)

Closes SYN-46

## Test plan
- [x] `ensemble skill --help` shows correct usage
- [x] Fetched 18KB SKILL.md from synthesis.devfolio.co
- [x] Correctly flagged domain mismatch (devfolio.co ≠ emilemarcelagustin.eth)

🤖 Generated with [Claude Code](https://claude.com/claude-code)