### PR TITLE
feat(site): build landing page + persistent sidebar layout

### DIFF
--- a/packages/site/src/app/globals.css
+++ b/packages/site/src/app/globals.css
@@ -1,1 +1,85 @@
 @import "tailwindcss";
+
+@theme {
+  --color-surface: #fafaf9;
+  --color-surface-raised: #f5f5f4;
+  --color-surface-sunken: #e7e5e4;
+  --color-ink: #1a1a1a;
+  --color-ink-muted: #78716c;
+  --color-ink-faint: #a8a29e;
+  --color-accent: #2563eb;
+  --color-accent-hover: #1d4ed8;
+  --color-pass: #16a34a;
+  --color-fail: #dc2626;
+  --color-border: #d6d3d1;
+  --color-sidebar: #ffffff;
+
+  --font-sans: ui-sans-serif, system-ui, -apple-system, "Segoe UI", sans-serif;
+  --font-mono: ui-monospace, "SF Mono", "Cascadia Code", "Fira Code", monospace;
+}
+
+html {
+  font-family: var(--font-sans);
+  color: var(--color-ink);
+  background-color: var(--color-surface);
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+body {
+  line-height: 1.6;
+}
+
+::selection {
+  background-color: var(--color-accent);
+  color: white;
+}
+
+/* Sidebar active link indicator */
+.nav-link {
+  position: relative;
+  transition: color 150ms ease;
+}
+
+.nav-link:hover {
+  color: var(--color-ink);
+}
+
+.nav-link::before {
+  content: "";
+  position: absolute;
+  left: -16px;
+  top: 50%;
+  transform: translateY(-50%);
+  width: 3px;
+  height: 0;
+  background-color: var(--color-accent);
+  border-radius: 2px;
+  transition: height 150ms ease;
+}
+
+.nav-link:hover::before {
+  height: 16px;
+}
+
+/* Staggered entrance animation */
+@keyframes fade-up {
+  from {
+    opacity: 0;
+    transform: translateY(12px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.animate-fade-up {
+  animation: fade-up 0.6s ease-out both;
+}
+
+.delay-1 { animation-delay: 0.1s; }
+.delay-2 { animation-delay: 0.2s; }
+.delay-3 { animation-delay: 0.3s; }
+.delay-4 { animation-delay: 0.4s; }
+.delay-5 { animation-delay: 0.5s; }

--- a/packages/site/src/app/layout.tsx
+++ b/packages/site/src/app/layout.tsx
@@ -1,9 +1,22 @@
 import type { Metadata } from "next";
+import { Sidebar } from "@/components/sidebar";
 import "./globals.css";
 
 export const metadata: Metadata = {
-  title: "Synthesis — Trust Resolution Layer",
-  description: "Verifiable agent identity, capability discovery, and version integrity anchored to ENS.",
+  title: "émile marcel agustín — Trust Resolution Layer",
+  description:
+    "Deliberate legibility as a stack. Verifiable agent identity, capability discovery, and version integrity anchored to ENS.",
+  openGraph: {
+    title: "émile marcel agustín",
+    description: "Trust Resolution Layer — deliberate legibility anchored to ENS.",
+    siteName: "emilemarcelagustin.eth",
+    type: "website",
+  },
+  twitter: {
+    card: "summary",
+    title: "émile marcel agustín",
+    description: "Trust Resolution Layer — deliberate legibility anchored to ENS.",
+  },
 };
 
 export default function RootLayout({
@@ -13,7 +26,12 @@ export default function RootLayout({
 }) {
   return (
     <html lang="en">
-      <body>{children}</body>
+      <body className="bg-[var(--color-surface)] text-[var(--color-ink)]">
+        <Sidebar />
+        <main className="md:ml-64 min-h-screen">
+          {children}
+        </main>
+      </body>
     </html>
   );
 }

--- a/packages/site/src/app/page.tsx
+++ b/packages/site/src/app/page.tsx
@@ -1,8 +1,138 @@
+import Link from "next/link";
+
+const LAYERS = [
+  { number: 0, name: "Personhood", protocol: "World ID", description: "Biometric proof that a unique human exists behind this identity" },
+  { number: 1, name: "Identity", protocol: "ENSIP-25", description: "On-chain agent registration linked to an ENS name" },
+  { number: 2, name: "Discovery", protocol: "ENSIP-26", description: "Machine-readable context — endpoints, capabilities, SKILL.md" },
+  { number: 3, name: "Integrity", protocol: "AIP", description: "Signed, versioned manifest with cryptographic lineage" },
+  { number: 4, name: "Capability", protocol: "DVS", description: "Domain-verified skill file proving what the agent can do" },
+] as const;
+
 export default function Home() {
   return (
-    <main className="flex min-h-screen flex-col items-center justify-center p-24">
-      <h1 className="text-4xl font-bold">Synthesis</h1>
-      <p className="mt-4 text-lg text-gray-600">Trust Resolution Layer</p>
-    </main>
+    <div className="px-8 md:px-16 py-16 md:py-24 max-w-2xl">
+      {/* Thesis */}
+      <section className="animate-fade-up">
+        <p className="text-lg leading-relaxed text-[var(--color-ink)]">
+          <em>The Abstracted Self</em> diagnosed algorithmic legibility as the
+          loss of interiority — the self dissolved into performativity under the
+          algorithmic gaze.
+        </p>
+        <p className="mt-4 text-lg leading-relaxed text-[var(--color-ink)]">
+          This site is the inversion: deliberate, conscious, architected
+          legibility. Not a retreat from visibility, but a submission to it — on
+          your own terms.
+        </p>
+      </section>
+
+      {/* Divider */}
+      <div className="mt-12 mb-12 h-px bg-[var(--color-border)] animate-fade-up delay-1" />
+
+      {/* The Stack */}
+      <section className="animate-fade-up delay-2">
+        <h2 className="text-xs font-medium uppercase tracking-widest text-[var(--color-ink-muted)] mb-6">
+          Trust Resolution Layer
+        </h2>
+        <p className="text-sm text-[var(--color-ink-muted)] mb-8 leading-relaxed">
+          Resolve any ENS name through five verification layers. Each layer
+          builds on the one below. The result is a progressive trust score —
+          from anonymous to fully legible.
+        </p>
+
+        <div className="space-y-4">
+          {LAYERS.map((layer) => (
+            <div
+              key={layer.number}
+              className="group flex gap-4 items-start"
+            >
+              <span className="font-mono text-xs text-[var(--color-ink-faint)] pt-0.5 w-4 shrink-0">
+                {layer.number}
+              </span>
+              <div>
+                <div className="flex items-baseline gap-2">
+                  <span className="text-sm font-medium text-[var(--color-ink)]">
+                    {layer.name}
+                  </span>
+                  <span className="font-mono text-[10px] text-[var(--color-ink-faint)]">
+                    {layer.protocol}
+                  </span>
+                </div>
+                <p className="text-sm text-[var(--color-ink-muted)] mt-0.5">
+                  {layer.description}
+                </p>
+              </div>
+            </div>
+          ))}
+        </div>
+      </section>
+
+      {/* Divider */}
+      <div className="mt-12 mb-12 h-px bg-[var(--color-border)] animate-fade-up delay-3" />
+
+      {/* Links */}
+      <section className="animate-fade-up delay-4">
+        <div className="flex flex-col gap-4">
+          <Link
+            href="/essay"
+            className="group flex items-baseline justify-between border-b border-[var(--color-border)] pb-3 transition-colors hover:border-[var(--color-accent)]"
+          >
+            <div>
+              <span className="text-sm font-medium text-[var(--color-ink)] group-hover:text-[var(--color-accent)] transition-colors">
+                Read the essay
+              </span>
+              <span className="block text-xs text-[var(--color-ink-muted)] mt-0.5">
+                "The Abstracted Self" — the intellectual foundation
+              </span>
+            </div>
+            <span className="text-[var(--color-ink-faint)] group-hover:text-[var(--color-accent)] transition-colors">
+              &rarr;
+            </span>
+          </Link>
+
+          <Link
+            href="/trust"
+            className="group flex items-baseline justify-between border-b border-[var(--color-border)] pb-3 transition-colors hover:border-[var(--color-accent)]"
+          >
+            <div>
+              <span className="text-sm font-medium text-[var(--color-ink)] group-hover:text-[var(--color-accent)] transition-colors">
+                View trust profile
+              </span>
+              <span className="block text-xs text-[var(--color-ink-muted)] mt-0.5">
+                Live resolution of emilemarcelagustin.eth
+              </span>
+            </div>
+            <span className="text-[var(--color-ink-faint)] group-hover:text-[var(--color-accent)] transition-colors">
+              &rarr;
+            </span>
+          </Link>
+
+          <Link
+            href="/resolve"
+            className="group flex items-baseline justify-between border-b border-[var(--color-border)] pb-3 transition-colors hover:border-[var(--color-accent)]"
+          >
+            <div>
+              <span className="text-sm font-medium text-[var(--color-ink)] group-hover:text-[var(--color-accent)] transition-colors">
+                Resolve any name
+              </span>
+              <span className="block text-xs text-[var(--color-ink-muted)] mt-0.5">
+                Interactive TRL demo — type any ENS name
+              </span>
+            </div>
+            <span className="text-[var(--color-ink-faint)] group-hover:text-[var(--color-accent)] transition-colors">
+              &rarr;
+            </span>
+          </Link>
+        </div>
+      </section>
+
+      {/* Bottom flourish */}
+      <div className="mt-16 animate-fade-up delay-5">
+        <p className="text-xs text-[var(--color-ink-faint)] leading-relaxed">
+          The site that argues legibility hollows out the self is itself the
+          most legible artifact on the internet. The content is the critique;
+          the container is the inversion. Both are true simultaneously.
+        </p>
+      </div>
+    </div>
   );
 }

--- a/packages/site/src/components/sidebar.tsx
+++ b/packages/site/src/components/sidebar.tsx
@@ -1,0 +1,89 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+
+const NAV_ITEMS = [
+  { href: "/essay", label: "essay" },
+  { href: "/trust", label: "trust" },
+  { href: "/resolve", label: "resolve" },
+  { href: "/token", label: "token" },
+] as const;
+
+export function Sidebar() {
+  const pathname = usePathname();
+
+  return (
+    <>
+      {/* Desktop sidebar */}
+      <aside className="hidden md:flex fixed left-0 top-0 h-screen w-64 flex-col justify-between border-r border-[var(--color-border)] bg-[var(--color-sidebar)] px-8 py-10">
+        <div>
+          {/* Identity */}
+          <Link href="/" className="block group">
+            <h1 className="text-lg font-semibold tracking-tight text-[var(--color-ink)] leading-snug">
+              émile marcel
+              <br />
+              agustín
+            </h1>
+            <p className="mt-2 font-mono text-xs text-[var(--color-ink-muted)] group-hover:text-[var(--color-accent)] transition-colors">
+              emilemarcelagustin.eth
+            </p>
+          </Link>
+
+          {/* Divider */}
+          <div className="mt-8 mb-6 h-px bg-[var(--color-border)]" />
+
+          {/* Navigation */}
+          <nav className="flex flex-col gap-1.5">
+            {NAV_ITEMS.map(({ href, label }) => (
+              <Link
+                key={href}
+                href={href}
+                className={`nav-link pl-0 py-1.5 text-sm transition-colors ${
+                  pathname === href
+                    ? "text-[var(--color-ink)] font-medium"
+                    : "text-[var(--color-ink-muted)]"
+                }`}
+              >
+                {label}
+              </Link>
+            ))}
+          </nav>
+        </div>
+
+        {/* Footer */}
+        <div className="text-xs text-[var(--color-ink-faint)]">
+          <p>Trust Resolution Layer</p>
+          <p className="mt-0.5">Synthesis, 2026</p>
+        </div>
+      </aside>
+
+      {/* Mobile top bar */}
+      <header className="md:hidden sticky top-0 z-50 flex items-center justify-between border-b border-[var(--color-border)] bg-[var(--color-sidebar)] px-5 py-3">
+        <Link href="/" className="flex items-baseline gap-2">
+          <span className="text-sm font-semibold tracking-tight text-[var(--color-ink)]">
+            émile marcel agustín
+          </span>
+          <span className="font-mono text-[10px] text-[var(--color-ink-muted)]">
+            .eth
+          </span>
+        </Link>
+        <nav className="flex gap-4">
+          {NAV_ITEMS.map(({ href, label }) => (
+            <Link
+              key={href}
+              href={href}
+              className={`text-xs transition-colors ${
+                pathname === href
+                  ? "text-[var(--color-ink)] font-medium"
+                  : "text-[var(--color-ink-muted)]"
+              }`}
+            >
+              {label}
+            </Link>
+          ))}
+        </nav>
+      </header>
+    </>
+  );
+}


### PR DESCRIPTION
## Summary
- Build landing page (`/`) with thesis on deliberate legibility
- Add persistent sidebar with identity + nav (all pages)
- Light editorial design: cream bg, dark text, blue accent
- Sidebar collapses to top nav on mobile
- Staggered entrance animations, hover indicators
- 5 trust layers described with protocol labels

Closes SYN-27

## Test plan
- [x] `pnpm --filter @synthesis/site build` compiles cleanly
- [x] `pnpm dev` — landing page renders correctly
- [x] Sidebar nav links present (routes not built yet — SYN-28 through SYN-31)
- [x] Mobile responsive — top bar replaces sidebar

🤖 Generated with [Claude Code](https://claude.com/claude-code)