### PR TITLE
feat(resolver): add gate() primitive (with @namera-ai/sdk dep)

### DIFF
--- a/packages/cli/index.ts
+++ b/packages/cli/index.ts
@@ -837,7 +837,7 @@ manifest.command("create", {
 	examples: [
 		{
 			args: { name: "emilemarcelagustin.eth" },
-			options: { version: "v1", output: "manifest-v1.json" },
+			options: { ver: "v1", output: "manifest-v1.json" },
 			description: "Create genesis manifest",
 		},
 	],

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -22,8 +22,8 @@
     "declaration": true,
     "declarationMap": true,
     "outDir": "./dist",
-    "rootDir": "./cli"
+    "rootDir": "./"
   },
-  "include": ["cli/**/*"],
+  "include": ["./**/*.ts"],
   "exclude": ["node_modules", "dist"]
 }

--- a/packages/resolver/package.json
+++ b/packages/resolver/package.json
@@ -21,6 +21,7 @@
     "format": "npx @biomejs/biome format --write ."
   },
   "dependencies": {
+    "@namera-ai/sdk": "^0.1.0",
     "@worldcoin/agentkit": "^0.1.5",
     "@zerodev/permissions": "^5.6.3",
     "@zerodev/sdk": "^5.5.8",

--- a/packages/resolver/package.json
+++ b/packages/resolver/package.json
@@ -18,7 +18,8 @@
     "build": "tsup src/index.ts --format esm --dts --outDir dist",
     "dev": "tsx src/index.ts",
     "lint": "npx @biomejs/biome lint --write .",
-    "format": "npx @biomejs/biome format --write ."
+    "format": "npx @biomejs/biome format --write .",
+    "test": "tsx --test src/*.test.ts"
   },
   "dependencies": {
     "@namera-ai/sdk": "^0.1.0",

--- a/packages/resolver/src/index.ts
+++ b/packages/resolver/src/index.ts
@@ -75,3 +75,11 @@ export {
   parseEnsip25Key,
   KNOWN_REGISTRIES,
 } from "./utils/erc7930.js";
+
+export {
+  gate,
+  TrustPolicySchema,
+  GateDecisionSchema,
+  type TrustPolicy,
+  type GateDecision,
+} from "./policy.js";

--- a/packages/resolver/src/policy.test.ts
+++ b/packages/resolver/src/policy.test.ts
@@ -1,0 +1,128 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { gate, type TrustPolicy } from "./policy.js";
+import { type TrustProfile } from "./schema.js";
+
+const defaultManifest: TrustProfile["manifest"] = {
+  found: false,
+  latestVersion: null,
+  lineageMode: null,
+  manifest: null,
+  signatureValid: true,
+  lineageDepth: 0,
+  lineageIntact: true,
+};
+
+function makeProfile(overrides: Partial<TrustProfile> = {}): TrustProfile {
+  return {
+    ensName: "test.eth",
+    address: null,
+    resolvedAt: 0,
+    trustScore: "full",
+    personhood: {
+      verified: false,
+      nullifierHash: null,
+      network: null,
+      agentBookAddress: null,
+    },
+    identity: {
+      verified: false,
+      registryAddress: null,
+      agentId: null,
+      registryChain: null,
+      tokenURI: null,
+      owner: null,
+    },
+    context: { found: false, raw: null, parsed: null, skillUrl: null },
+    manifest: defaultManifest,
+    skill: { found: false, domainVerified: false, content: null, url: null },
+    ...overrides,
+  };
+}
+
+const strictPolicy: TrustPolicy = {
+  minTier: "full",
+  requireLineage: true,
+  requireSig: true,
+  allowSelf: false,
+};
+
+test("denies when caller is self and allowSelf is false", () => {
+  const profile = makeProfile({ ensName: "alice.eth" });
+  const decision = gate(profile, strictPolicy, "alice.eth");
+  assert.equal(decision.allow, false);
+  assert.equal(decision.reason, "self-resolution not permitted by policy");
+});
+
+test("denies when trust tier is below required minTier", () => {
+  const profile = makeProfile({ trustScore: "registered" });
+  const policy: TrustPolicy = {
+    minTier: "verified",
+    requireLineage: false,
+    requireSig: false,
+    allowSelf: true,
+  };
+  const decision = gate(profile, policy);
+  assert.equal(decision.allow, false);
+  assert.match(decision.reason, /tier registered below required verified/);
+});
+
+test("denies when manifest signature is invalid", () => {
+  const profile = makeProfile({
+    manifest: { ...defaultManifest, found: true, signatureValid: false },
+  });
+  const policy: TrustPolicy = {
+    minTier: "none",
+    requireLineage: false,
+    requireSig: true,
+    allowSelf: true,
+  };
+  const decision = gate(profile, policy);
+  assert.equal(decision.allow, false);
+  assert.equal(
+    decision.reason,
+    "manifest signature does not match current ENS owner",
+  );
+});
+
+test("denies when manifest lineage is broken", () => {
+  const profile = makeProfile({
+    manifest: {
+      ...defaultManifest,
+      found: true,
+      lineageIntact: false,
+      lineageDepth: 2,
+    },
+  });
+  const policy: TrustPolicy = {
+    minTier: "none",
+    requireLineage: true,
+    requireSig: false,
+    allowSelf: true,
+  };
+  const decision = gate(profile, policy);
+  assert.equal(decision.allow, false);
+  assert.match(decision.reason, /manifest lineage broken at v2/);
+});
+
+test("allows when all gates pass", () => {
+  const profile = makeProfile({
+    ensName: "alice.eth",
+    trustScore: "full",
+    manifest: {
+      ...defaultManifest,
+      found: true,
+      signatureValid: true,
+      lineageIntact: true,
+    },
+  });
+  const policy: TrustPolicy = {
+    minTier: "verified",
+    requireLineage: true,
+    requireSig: true,
+    allowSelf: false,
+  };
+  const decision = gate(profile, policy, "bob.eth");
+  assert.equal(decision.allow, true);
+  assert.equal(decision.reason, "all gates passed at tier full");
+});

--- a/packages/resolver/src/policy.test.ts
+++ b/packages/resolver/src/policy.test.ts
@@ -54,6 +54,13 @@ test("denies when caller is self and allowSelf is false", () => {
   assert.equal(decision.reason, "self-resolution not permitted by policy");
 });
 
+test("denies when caller is self with different casing (ENSIP-15 normalization)", () => {
+  const profile = makeProfile({ ensName: "alice.eth" });
+  const decision = gate(profile, strictPolicy, "Alice.eth");
+  assert.equal(decision.allow, false);
+  assert.equal(decision.reason, "self-resolution not permitted by policy");
+});
+
 test("denies when trust tier is below required minTier", () => {
   const profile = makeProfile({ trustScore: "registered" });
   const policy: TrustPolicy = {

--- a/packages/resolver/src/policy.ts
+++ b/packages/resolver/src/policy.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 import { TrustTier, TrustProfileSchema, type TrustProfile } from "./schema.js";
+import { normalizeName } from "./utils/ens.js";
 
 export const TrustPolicySchema = z.object({
   minTier: TrustTier.default("verified"),
@@ -34,14 +35,21 @@ export function gate(
   policy: TrustPolicy,
   callerEns?: string,
 ): GateDecision {
-  // 1. Deny: self disallowed
-  if (!policy.allowSelf && callerEns === profile.ensName) {
-    return {
-      allow: false,
-      reason: "self-resolution not permitted by policy",
-      profile,
-      policy,
-    };
+  // 1. Deny: self disallowed.
+  // Compare normalized names — ENS is case-insensitive per ENSIP-15, so a
+  // raw === would let "Alice.eth" bypass an allowSelf:false gate against a
+  // profile resolved from "alice.eth".
+  if (!policy.allowSelf && callerEns) {
+    const caller = normalizeName(callerEns);
+    const target = normalizeName(profile.ensName);
+    if (caller === target) {
+      return {
+        allow: false,
+        reason: "self-resolution not permitted by policy",
+        profile,
+        policy,
+      };
+    }
   }
 
   // 2. Deny: tier below minimum

--- a/packages/resolver/src/policy.ts
+++ b/packages/resolver/src/policy.ts
@@ -1,0 +1,88 @@
+import { z } from "zod";
+import { TrustTier, TrustProfileSchema, type TrustProfile } from "./schema.js";
+
+export const TrustPolicySchema = z.object({
+  minTier: TrustTier.default("verified"),
+  requireLineage: z.boolean().default(true),
+  requireSig: z.boolean().default(true),
+  allowSelf: z.boolean().default(true),
+});
+export type TrustPolicy = z.infer<typeof TrustPolicySchema>;
+
+export const GateDecisionSchema = z.object({
+  allow: z.boolean(),
+  reason: z.string(),
+  profile: TrustProfileSchema,
+  policy: TrustPolicySchema,
+});
+export type GateDecision = z.infer<typeof GateDecisionSchema>;
+
+const TIER_RANK: Record<z.infer<typeof TrustTier>, number> = {
+  none: 0,
+  registered: 1,
+  discoverable: 2,
+  verified: 3,
+  full: 4,
+};
+
+function tierRank(t: z.infer<typeof TrustTier>): number {
+  return TIER_RANK[t];
+}
+
+export function gate(
+  profile: TrustProfile,
+  policy: TrustPolicy,
+  callerEns?: string,
+): GateDecision {
+  // 1. Deny: self disallowed
+  if (!policy.allowSelf && callerEns === profile.ensName) {
+    return {
+      allow: false,
+      reason: "self-resolution not permitted by policy",
+      profile,
+      policy,
+    };
+  }
+
+  // 2. Deny: tier below minimum
+  if (tierRank(profile.trustScore) < tierRank(policy.minTier)) {
+    return {
+      allow: false,
+      reason: `tier ${profile.trustScore} below required ${policy.minTier}`,
+      profile,
+      policy,
+    };
+  }
+
+  // 3. Deny: signature invalid (only when manifest was found)
+  if (
+    policy.requireSig &&
+    profile.manifest.found &&
+    !profile.manifest.signatureValid
+  ) {
+    return {
+      allow: false,
+      reason: "manifest signature does not match current ENS owner",
+      profile,
+      policy,
+    };
+  }
+
+  // 4. Deny: lineage broken
+  if (policy.requireLineage && !profile.manifest.lineageIntact) {
+    return {
+      allow: false,
+      reason: `manifest lineage broken at v${profile.manifest.lineageDepth}`,
+      profile,
+      policy,
+    };
+  }
+
+  // 5. Allow
+  return {
+    allow: true,
+    reason: `all gates passed at tier ${profile.trustScore}`,
+    profile,
+    policy,
+  };
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -60,6 +60,9 @@ importers:
 
   packages/resolver:
     dependencies:
+      '@namera-ai/sdk':
+        specifier: ^0.1.0
+        version: 0.1.0(viem@2.47.5(typescript@5.9.3)(zod@3.25.76))
       '@worldcoin/agentkit':
         specifier: ^0.1.5
         version: 0.1.5(ethers@6.16.0)(typescript@5.9.3)
@@ -639,6 +642,11 @@ packages:
   '@multiformats/multiaddr@13.0.1':
     resolution: {integrity: sha512-XToN915cnfr6Lr9EdGWakGJbPT0ghpg/850HvdC+zFX8XvpLZElwa8synCiwa8TuvKNnny6m8j8NVBNCxhIO3g==}
 
+  '@namera-ai/sdk@0.1.0':
+    resolution: {integrity: sha512-nrBMai1fMy/ZnG9z1hDaT3d/lBLIl2znhnTnjIQNegjRoKedjO1NbBA14furWs/GUOlQ9N7SQZHvcnm5iMukhQ==}
+    peerDependencies:
+      viem: ^2.47.2
+
   '@next/env@15.5.14':
     resolution: {integrity: sha512-aXeirLYuASxEgi4X4WhfXsShCFxWDfNn/8ZeC5YXAS2BB4A8FJi1kwwGL6nvMVboE7fZCzmJPNdMvVHc8JpaiA==}
 
@@ -1058,9 +1066,24 @@ packages:
 
   '@worldcoin/agentkit@0.1.5':
     resolution: {integrity: sha512-Kde4xxSsjEYTUws+eSx594nlFMsj76fGGjcDw3UQ8MohWgb7kiFgeL/fH4EbmV9OdaMoKOnJDgcZzZGpH9BE7g==}
+    deprecated: 0.0.1
 
   '@x402/core@2.7.0':
     resolution: {integrity: sha512-2l1QaRO50qtWpnTJed45HtGRAUp3z2Mep1caNCuaNBzeiE8OfWfuXmip+ujgp3vWZHxRqag221aRSnKbA6gDaQ==}
+
+  '@zerodev/multi-chain-ecdsa-validator@5.4.5':
+    resolution: {integrity: sha512-cmQcsl5WbjnyQuhAS76BUqsHGtUOfWqdkMlm60s75kmRKzF5PiKzRpWIZyeISVmJV0F4P5u1keo1xYONEFiw1w==}
+    peerDependencies:
+      '@zerodev/sdk': ^5.4.0
+      '@zerodev/webauthn-key': ^5.4.0
+      viem: ^2.28.0
+
+  '@zerodev/passkey-validator@5.6.0':
+    resolution: {integrity: sha512-ItnPs/6m3pT8tWaLqt31AFFQ4tAc5O01gtXP0Y7RW7xfuqUbgwYOghyeKMEkw6LfYykUWLhapL4B5c0CBYkgvg==}
+    peerDependencies:
+      '@zerodev/sdk': ^5.4.0
+      '@zerodev/webauthn-key': ^5.4.2
+      viem: ^2.28.0
 
   '@zerodev/permissions@5.6.3':
     resolution: {integrity: sha512-MwW3Eo3rB5ViOKdY6NUoyvmQTV/bCbOZbmQMTYQqAT7B8rdI9jo44nNONMOHIhDkfF4VFhQ9+M50cCZLA/6zcg==}
@@ -1077,6 +1100,13 @@ packages:
   '@zerodev/webauthn-key@5.5.0':
     resolution: {integrity: sha512-AbD2d/qrsX7AWxJMEfwxnLbp1TjiUjc1V4ne3Q40UJxKe+lW64Td+y8OD0qSFMqgN6rQxJZ0aOAXmat8H6xluA==}
     peerDependencies:
+      viem: ^2.28.0
+
+  '@zerodev/weighted-validator@5.5.1':
+    resolution: {integrity: sha512-fQhlI3OZNm0ONFeMJKqV72G/oXUX6D/7wmofgSBSEVvzummvjwVj3iSj1cz/sht5AfaZVteWnX8eIQLutJwTaQ==}
+    peerDependencies:
+      '@zerodev/sdk': ^5.4.0
+      '@zerodev/webauthn-key': ^5.4.2
       viem: ^2.28.0
 
   abitype@1.2.3:
@@ -2902,6 +2932,16 @@ snapshots:
       uint8-varint: 2.0.4
       uint8arrays: 5.1.0
 
+  '@namera-ai/sdk@0.1.0(viem@2.47.5(typescript@5.9.3)(zod@3.25.76))':
+    dependencies:
+      '@zerodev/multi-chain-ecdsa-validator': 5.4.5(@zerodev/sdk@5.5.8(viem@2.47.5(typescript@5.9.3)(zod@3.25.76)))(@zerodev/webauthn-key@5.5.0(viem@2.47.5(typescript@5.9.3)(zod@3.25.76)))(viem@2.47.5(typescript@5.9.3)(zod@3.25.76))
+      '@zerodev/passkey-validator': 5.6.0(@zerodev/sdk@5.5.8(viem@2.47.5(typescript@5.9.3)(zod@3.25.76)))(@zerodev/webauthn-key@5.5.0(viem@2.47.5(typescript@5.9.3)(zod@3.25.76)))(viem@2.47.5(typescript@5.9.3)(zod@3.25.76))
+      '@zerodev/permissions': 5.6.3(@zerodev/sdk@5.5.8(viem@2.47.5(typescript@5.9.3)(zod@3.25.76)))(@zerodev/webauthn-key@5.5.0(viem@2.47.5(typescript@5.9.3)(zod@3.25.76)))(viem@2.47.5(typescript@5.9.3)(zod@3.25.76))
+      '@zerodev/sdk': 5.5.8(viem@2.47.5(typescript@5.9.3)(zod@3.25.76))
+      '@zerodev/webauthn-key': 5.5.0(viem@2.47.5(typescript@5.9.3)(zod@3.25.76))
+      '@zerodev/weighted-validator': 5.5.1(@zerodev/sdk@5.5.8(viem@2.47.5(typescript@5.9.3)(zod@3.25.76)))(@zerodev/webauthn-key@5.5.0(viem@2.47.5(typescript@5.9.3)(zod@3.25.76)))(viem@2.47.5(typescript@5.9.3)(zod@3.25.76))
+      viem: 2.47.5(typescript@5.9.3)(zod@3.25.76)
+
   '@next/env@15.5.14': {}
 
   '@next/mdx@15.5.14(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.4))':
@@ -3243,6 +3283,23 @@ snapshots:
     dependencies:
       zod: 3.25.76
 
+  '@zerodev/multi-chain-ecdsa-validator@5.4.5(@zerodev/sdk@5.5.8(viem@2.47.5(typescript@5.9.3)(zod@3.25.76)))(@zerodev/webauthn-key@5.5.0(viem@2.47.5(typescript@5.9.3)(zod@3.25.76)))(viem@2.47.5(typescript@5.9.3)(zod@3.25.76))':
+    dependencies:
+      '@simplewebauthn/browser': 9.0.1
+      '@simplewebauthn/typescript-types': 8.3.4
+      '@zerodev/sdk': 5.5.8(viem@2.47.5(typescript@5.9.3)(zod@3.25.76))
+      '@zerodev/webauthn-key': 5.5.0(viem@2.47.5(typescript@5.9.3)(zod@3.25.76))
+      merkletreejs: 0.3.11
+      viem: 2.47.5(typescript@5.9.3)(zod@3.25.76)
+
+  '@zerodev/passkey-validator@5.6.0(@zerodev/sdk@5.5.8(viem@2.47.5(typescript@5.9.3)(zod@3.25.76)))(@zerodev/webauthn-key@5.5.0(viem@2.47.5(typescript@5.9.3)(zod@3.25.76)))(viem@2.47.5(typescript@5.9.3)(zod@3.25.76))':
+    dependencies:
+      '@noble/curves': 1.9.1
+      '@simplewebauthn/browser': 8.3.7
+      '@zerodev/sdk': 5.5.8(viem@2.47.5(typescript@5.9.3)(zod@3.25.76))
+      '@zerodev/webauthn-key': 5.5.0(viem@2.47.5(typescript@5.9.3)(zod@3.25.76))
+      viem: 2.47.5(typescript@5.9.3)(zod@3.25.76)
+
   '@zerodev/permissions@5.6.3(@zerodev/sdk@5.5.8(viem@2.47.5(typescript@5.9.3)(zod@3.25.76)))(@zerodev/webauthn-key@5.5.0(viem@2.47.5(typescript@5.9.3)(zod@3.25.76)))(viem@2.47.5(typescript@5.9.3)(zod@3.25.76))':
     dependencies:
       '@simplewebauthn/browser': 9.0.1
@@ -3261,6 +3318,14 @@ snapshots:
       '@noble/curves': 1.9.1
       '@simplewebauthn/browser': 8.3.7
       '@simplewebauthn/types': 12.0.0
+      viem: 2.47.5(typescript@5.9.3)(zod@3.25.76)
+
+  '@zerodev/weighted-validator@5.5.1(@zerodev/sdk@5.5.8(viem@2.47.5(typescript@5.9.3)(zod@3.25.76)))(@zerodev/webauthn-key@5.5.0(viem@2.47.5(typescript@5.9.3)(zod@3.25.76)))(viem@2.47.5(typescript@5.9.3)(zod@3.25.76))':
+    dependencies:
+      '@noble/curves': 1.9.1
+      '@simplewebauthn/browser': 8.3.7
+      '@zerodev/sdk': 5.5.8(viem@2.47.5(typescript@5.9.3)(zod@3.25.76))
+      '@zerodev/webauthn-key': 5.5.0(viem@2.47.5(typescript@5.9.3)(zod@3.25.76))
       viem: 2.47.5(typescript@5.9.3)(zod@3.25.76)
 
   abitype@1.2.3(typescript@5.9.3)(zod@3.25.76):


### PR DESCRIPTION
## Summary

First of four serialized PRs landing **Layer A — TRL Policy + Signers** (plan: `plans/trl-policy-and-signers.md`). Bundles Phase A.0 (Namera SDK dep + a pre-existing cli build fix) with Phase A.1 (gate primitive + tests).

**Adds:**
- `gate(profile, policy, callerEns?) → GateDecision` — pure function in `packages/resolver/src/policy.ts`. Five branches evaluated in spec order: self-disallowed → tier-below → sig-invalid → lineage-broken → allow.
- `TrustPolicy` + `GateDecision` Zod schemas.
- `@namera-ai/sdk@^0.1.0` dependency in `packages/resolver` (needed for PR 2's signer adapter; resolves cleanly against existing `@zerodev/*` versions, no bumps).
- `pnpm test` script via `node:test` + `tsx --test` (no new devDeps).
- Re-exports `gate`, `TrustPolicy`, `TrustPolicySchema`, `GateDecision`, `GateDecisionSchema` from the resolver barrel.

**Fixes (incidental, blocked the build):**
- `packages/cli/tsconfig.json` — `rootDir`/`include` pointed to a non-existent `./cli/` subdirectory.
- `packages/cli/index.ts:840` — manifest example used `version` but the schema declares `ver`.

**Closes:** SYN-50, SYN-51, SYN-55, SYN-56, SYN-57, SYN-58, SYN-59, SYN-60, SYN-61.

**Tracking:** SYN-76 (this PR).

## Test plan

- [x] `pnpm -r build` clean across resolver, cli, site
- [x] `pnpm --filter @synthesis/resolver test` — 5/5 pass (one per gate decision branch)
- [ ] Reviewer: `pnpm install && pnpm -r build && pnpm --filter @synthesis/resolver test`
- [ ] Reviewer: spot-check the decision branch ordering in `packages/resolver/src/policy.ts` (self → tier → sig → lineage → allow)
- [ ] Reviewer: confirm no version bump (held until PR 4)

## Up next

PR 2 (`feat/trl-signer`) adds the `Signer` interface + local + namera adapters on top of this. Per the 4-PR serialize plan, PR 2 opens after this one merges and rebases on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)