### PR TITLE
feat(resolver): add Signer interface + local + namera adapters

### DIFF
--- a/packages/resolver/package.json
+++ b/packages/resolver/package.json
@@ -19,7 +19,7 @@
     "dev": "tsx src/index.ts",
     "lint": "npx @biomejs/biome lint --write .",
     "format": "npx @biomejs/biome format --write .",
-    "test": "tsx --test src/*.test.ts"
+    "test": "tsx --test src/*.test.ts src/wallets/*.test.ts"
   },
   "dependencies": {
     "@namera-ai/sdk": "^0.1.0",

--- a/packages/resolver/src/index.ts
+++ b/packages/resolver/src/index.ts
@@ -83,3 +83,12 @@ export {
   type TrustPolicy,
   type GateDecision,
 } from "./policy.js";
+
+export {
+  createLocalSigner,
+  createNameraSigner,
+  type Batch,
+  type Signer,
+  type CreateLocalSignerOptions,
+  type CreateNameraSignerOptions,
+} from "./wallets/index.js";

--- a/packages/resolver/src/wallets/index.ts
+++ b/packages/resolver/src/wallets/index.ts
@@ -1,0 +1,45 @@
+/**
+ * Signer abstraction — uniform interface for "this address signs and broadcasts
+ * a transaction." Two adapters live alongside this file:
+ *
+ *   - createLocalSigner — viem WalletClient over a private-key EOA
+ *   - createNameraSigner — ZeroDev kernel account via @namera-ai/sdk
+ *
+ * The resolver itself is read-only; this module exists in packages/resolver
+ * because that's where the schema + utilities live, but it performs no
+ * resolution. Consuming applications (e.g. TrustSwap) wire signers + gate()
+ * together to express "resolve who → decide allow → sign and broadcast."
+ */
+
+/** A logical batch of contract calls. EOAs ignore `atomic` and send sequentially. */
+export interface Batch {
+  chainId: number;
+  /**
+   * When true, all `calls` execute as a single onchain transaction. Smart-account
+   * signers (Namera) honor this; EOA signers (local) emit a warning and fall
+   * back to sequential sends.
+   */
+  atomic: boolean;
+  calls: Array<{ to: `0x${string}`; data: `0x${string}`; value: bigint }>;
+}
+
+/** A signer over the {@link Batch} shape. Returned by adapter factories. */
+export interface Signer {
+  /** Address that signs and submits — EOA address for local, kernel account address for namera. */
+  address: `0x${string}`;
+  /**
+   * Submit one or more batches; returns the broadcast tx hash (or user-op hash,
+   * depending on the adapter's receipt handling).
+   *
+   * Multiple batches are processed in array order. Within a single batch, calls
+   * are sent in order — and atomically as a single tx if `batch.atomic === true`
+   * and the signer supports it.
+   */
+  execute(batches: Batch[]): Promise<`0x${string}`>;
+}
+
+export { createLocalSigner, type CreateLocalSignerOptions } from "./local.js";
+export {
+  createNameraSigner,
+  type CreateNameraSignerOptions,
+} from "./namera.js";

--- a/packages/resolver/src/wallets/index.ts
+++ b/packages/resolver/src/wallets/index.ts
@@ -20,6 +20,13 @@ export interface Batch {
    * back to sequential sends.
    */
   atomic: boolean;
+  /**
+   * Optional ZeroDev custom nonce key. Smart-account signers (Namera) use this
+   * to run independent batches in parallel nonce lanes via `executeTransaction`.
+   * EOA signers (local) ignore this field — Ethereum's per-address nonce is
+   * strictly sequential, so EOAs have no equivalent concept.
+   */
+  nonceKey?: string;
   calls: Array<{ to: `0x${string}`; data: `0x${string}`; value: bigint }>;
 }
 

--- a/packages/resolver/src/wallets/local.test.ts
+++ b/packages/resolver/src/wallets/local.test.ts
@@ -27,6 +27,31 @@ test("createLocalSigner returns a Signer with address + execute()", () => {
   assert.equal(typeof signer.execute, "function");
 });
 
+test("createLocalSigner.execute() rejects batches with wrong chainId", async () => {
+  const signer = createLocalSigner({
+    privateKey: TEST_PRIVATE_KEY,
+    chain: base, // chainId 8453
+    rpc: "http://localhost:8545",
+  });
+  await assert.rejects(
+    () =>
+      signer.execute([
+        {
+          chainId: 1, // mainnet — does not match the signer's base
+          atomic: false,
+          calls: [
+            {
+              to: "0x0000000000000000000000000000000000000001",
+              data: "0x",
+              value: 0n,
+            },
+          ],
+        },
+      ]),
+    /batch\.chainId 1 does not match signer chain 8453/,
+  );
+});
+
 // Note: end-to-end execute(batches) testing requires a live RPC or a more
 // involved viem transport mock. Covered by TrustSwap Phase 0's live
 // USDC→WETH broadcast on Base (see plans/trust-gated-swap.md). Here we

--- a/packages/resolver/src/wallets/local.test.ts
+++ b/packages/resolver/src/wallets/local.test.ts
@@ -1,0 +1,33 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { base } from "viem/chains";
+import { createLocalSigner } from "./local.js";
+
+// Hardhat default account 0 — well-known test key, never use on mainnet.
+const TEST_PRIVATE_KEY =
+  "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80" as const;
+const TEST_ADDRESS = "0xf39Fd6e51aad88F6F4ce6aB8827279cfFFb92266" as const;
+
+test("createLocalSigner derives address from private key", () => {
+  const signer = createLocalSigner({
+    privateKey: TEST_PRIVATE_KEY,
+    chain: base,
+    rpc: "http://localhost:8545",
+  });
+  assert.equal(signer.address.toLowerCase(), TEST_ADDRESS.toLowerCase());
+});
+
+test("createLocalSigner returns a Signer with address + execute()", () => {
+  const signer = createLocalSigner({
+    privateKey: TEST_PRIVATE_KEY,
+    chain: base,
+    rpc: "http://localhost:8545",
+  });
+  assert.match(signer.address, /^0x[a-fA-F0-9]{40}$/);
+  assert.equal(typeof signer.execute, "function");
+});
+
+// Note: end-to-end execute(batches) testing requires a live RPC or a more
+// involved viem transport mock. Covered by TrustSwap Phase 0's live
+// USDC→WETH broadcast on Base (see plans/trust-gated-swap.md). Here we
+// test only what's verifiable without network I/O.

--- a/packages/resolver/src/wallets/local.ts
+++ b/packages/resolver/src/wallets/local.ts
@@ -1,0 +1,66 @@
+import { createWalletClient, http, type Chain, type Hex } from "viem";
+import { privateKeyToAccount } from "viem/accounts";
+import type { Batch, Signer } from "./index.js";
+
+export interface CreateLocalSignerOptions {
+  /** 0x-prefixed 32-byte private key. */
+  privateKey: Hex;
+  /** viem chain config (e.g. base, baseSepolia from "viem/chains"). */
+  chain: Chain;
+  /** RPC URL for the chain. */
+  rpc: string;
+}
+
+/**
+ * Create a Signer backed by a viem WalletClient over a private-key EOA.
+ *
+ * For early development and as a fallback when smart-account signers (Namera)
+ * are unavailable. EOAs cannot atomically batch — `Batch.atomic === true` is
+ * honored as best-effort sequential sends, with a console.warn if more than
+ * one call would be lost. Use `createNameraSigner` for true atomic batches
+ * via ERC-4337.
+ */
+export function createLocalSigner(opts: CreateLocalSignerOptions): Signer {
+  const account = privateKeyToAccount(opts.privateKey);
+  const walletClient = createWalletClient({
+    account,
+    chain: opts.chain,
+    transport: http(opts.rpc),
+  });
+
+  return {
+    address: account.address,
+    async execute(batches: Batch[]): Promise<`0x${string}`> {
+      // EOA limitation: no atomic batching. Warn loudly when callers expect
+      // it so they don't silently rely on a guarantee they're not getting.
+      const wantsAtomic = batches.some(
+        (b) => b.atomic && b.calls.length > 1,
+      );
+      if (wantsAtomic) {
+        console.warn(
+          "[createLocalSigner] atomic batch requested but EOAs cannot batch atomically; " +
+            "sending calls sequentially. Use createNameraSigner for atomic batches.",
+        );
+      }
+
+      let lastHash: `0x${string}` | undefined;
+      for (const batch of batches) {
+        for (const call of batch.calls) {
+          lastHash = await walletClient.sendTransaction({
+            to: call.to,
+            data: call.data,
+            value: call.value,
+            chain: opts.chain,
+          });
+        }
+      }
+
+      if (!lastHash) {
+        throw new Error(
+          "[createLocalSigner] execute() called with no calls to submit",
+        );
+      }
+      return lastHash;
+    },
+  };
+}

--- a/packages/resolver/src/wallets/local.ts
+++ b/packages/resolver/src/wallets/local.ts
@@ -31,6 +31,19 @@ export function createLocalSigner(opts: CreateLocalSignerOptions): Signer {
   return {
     address: account.address,
     async execute(batches: Batch[]): Promise<`0x${string}`> {
+      // Reject wrong-chain batches before any send. The Signer interface
+      // treats batch.chainId as a routing key; a local signer is locked to
+      // a single chain, so anything else is a programming error and must
+      // surface loudly rather than silently broadcast on the wrong network.
+      for (const batch of batches) {
+        if (batch.chainId !== opts.chain.id) {
+          throw new Error(
+            `[createLocalSigner] batch.chainId ${batch.chainId} does not match signer chain ${opts.chain.id} (${opts.chain.name}). ` +
+              "Local signers are locked to a single chain at construction; reuse Batch builders only when chainId matches.",
+          );
+        }
+      }
+
       // EOA limitation: no atomic batching. Warn loudly when callers expect
       // it so they don't silently rely on a guarantee they're not getting.
       const wantsAtomic = batches.some(

--- a/packages/resolver/src/wallets/namera.test.ts
+++ b/packages/resolver/src/wallets/namera.test.ts
@@ -1,0 +1,34 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { base } from "viem/chains";
+import { createNameraSigner } from "./namera.js";
+
+test("createNameraSigner is exported as an async function", () => {
+  assert.equal(typeof createNameraSigner, "function");
+  // Async fns have a `then`-less return at definition time; the call below
+  // returns a Promise. We don't invoke with valid params here — we just
+  // confirm the export shape.
+  assert.equal(createNameraSigner.constructor.name, "AsyncFunction");
+});
+
+test("createNameraSigner propagates errors from readSessionKey", async () => {
+  await assert.rejects(
+    () =>
+      createNameraSigner({
+        readSessionKey: () => Promise.reject(new Error("stub: keystore unavailable")),
+        sessionKeyPrivateKey:
+          "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80",
+        bundlerUrl: "http://localhost:4337",
+        chain: base,
+        rpc: "http://localhost:8545",
+        kernelVersion: "0.3.1",
+      }),
+    /keystore unavailable/,
+  );
+});
+
+// Note: end-to-end execute(batches) testing requires a real ZeroDev kernel
+// account, a funded session key, and a live ERC-4337 bundler. Covered by
+// TrustSwap Phase 0's live USDC→WETH broadcast on Base (see
+// plans/trust-gated-swap.md). Here we test only the construction-time
+// surface that's verifiable without on-chain state.

--- a/packages/resolver/src/wallets/namera.ts
+++ b/packages/resolver/src/wallets/namera.ts
@@ -1,0 +1,107 @@
+import { createSessionKeyClient } from "@namera-ai/sdk/session-key";
+import { executeTransaction } from "@namera-ai/sdk/transaction";
+import {
+  createPublicClient,
+  http,
+  type Chain,
+  type EntryPointVersion,
+  type Hex,
+} from "viem";
+import { privateKeyToAccount } from "viem/accounts";
+import type { Batch, Signer } from "./index.js";
+
+export interface CreateNameraSignerOptions {
+  /**
+   * Returns the base64-serialized session-key permission account string.
+   *
+   * IO is dependency-injected so the resolver stays free of Node-only deps
+   * (allowing the package to be safely consumed by browser bundlers like
+   * Next.js webpack). Callers in Node typically pass:
+   *   `() => readFile(path, "utf-8").then(s => s.trim())`
+   */
+  readSessionKey: () => Promise<string>;
+  /** 0x-prefixed 32-byte private key for the session signer (NOT the owner key). */
+  sessionKeyPrivateKey: Hex;
+  /** ERC-4337 bundler URL for the chain (Pimlico/Alchemy). */
+  bundlerUrl: string;
+  /** viem chain config (e.g. base from "viem/chains"). */
+  chain: Chain;
+  /** RPC URL for the public client. */
+  rpc: string;
+  /** ERC-4337 entrypoint version. Defaults to "0.7". */
+  entrypointVersion?: EntryPointVersion;
+  /**
+   * ZeroDev kernel version (e.g. KERNEL_V3_3 from @zerodev/sdk/constants).
+   * Must match what the session key was issued for.
+   */
+  // biome-ignore lint/suspicious/noExplicitAny: GetKernelVersion is a deeply
+  // conditional generic; we pass through to namera, which validates at runtime.
+  kernelVersion: any;
+}
+
+/**
+ * Create a Signer backed by a Namera session-key client (ZeroDev kernel account
+ * via @namera-ai/sdk).
+ *
+ * **Execution-only.** This adapter consumes a previously-issued, serialized
+ * session key plus the session signer's private key. It does NOT require or
+ * instantiate the owner key — the owner key lives in an encrypted keystore
+ * off-droplet, used only at session-key issuance time (a one-time ceremony
+ * the consuming application performs separately).
+ *
+ * **Policy-agnostic.** Onchain policies (call / gas / rate-limit / timestamp)
+ * are baked into the session key during issuance. What this signer can and
+ * cannot do is determined by the validator state on chain, not by anything
+ * here. Consuming apps choose their policies during issuance.
+ *
+ * `execute(batches)` forwards to `executeTransaction` and returns the LAST
+ * batch's onchain transaction hash (extracted from its UserOperationReceipt).
+ * Throws if every batch failed to broadcast.
+ */
+export async function createNameraSigner(
+  opts: CreateNameraSignerOptions,
+): Promise<Signer> {
+  const serializedAccount = (await opts.readSessionKey()).trim();
+  const client = createPublicClient({
+    chain: opts.chain,
+    transport: http(opts.rpc),
+  });
+  const signer = privateKeyToAccount(opts.sessionKeyPrivateKey);
+
+  const sessionKeyClient = await createSessionKeyClient({
+    type: "ecdsa",
+    signer,
+    client,
+    serializedAccount,
+    bundlerTransport: http(opts.bundlerUrl),
+    chain: opts.chain,
+    entrypointVersion: opts.entrypointVersion ?? "0.7",
+    kernelVersion: opts.kernelVersion,
+    // biome-ignore lint/suspicious/noExplicitAny: heavy generic narrowing —
+    // namera's createSessionKeyClient requires param-tuple inference that
+    // doesn't survive our thinner wrapper signature.
+  } as any);
+
+  return {
+    address: sessionKeyClient.account.address,
+    async execute(batches: Batch[]): Promise<`0x${string}`> {
+      // Our Batch shape matches namera's: { chainId, atomic, calls: { to, data, value }[] }.
+      const receipts = await executeTransaction({
+        batches,
+        clients: [sessionKeyClient],
+      });
+
+      // Return the LAST successful receipt's onchain tx hash. Walk backwards
+      // so the most recent send wins (matches the local signer's contract).
+      for (let i = receipts.length - 1; i >= 0; i--) {
+        const receipt = receipts[i];
+        if (receipt) {
+          return receipt.receipt.transactionHash;
+        }
+      }
+      throw new Error(
+        "[createNameraSigner] all batches failed to broadcast",
+      );
+    },
+  };
+}


### PR DESCRIPTION
## Summary

Second of four serialized PRs landing **Layer A — TRL Policy + Signers** (plan: `plans/trl-policy-and-signers.md`). Adds Phase A.2 — the first write-side abstraction TRL exposes for consumers.

**The resolver itself stays read-only.** These adapters live in `packages/resolver` because that's where the schema + utilities live, but they perform no resolution. Consuming applications (TrustSwap, future agent apps) wire signers + `gate()` together to express "resolve who → decide allow → sign and broadcast."

**Adds — three new files in `packages/resolver/src/wallets/`:**

- **`index.ts`** — `Signer` interface + `Batch` type. Generic over EOA and smart-account signers. `Batch` shape `{ chainId, atomic, calls: { to, data, value: bigint }[] }` matches Namera's exactly so the namera adapter is pass-through.
- **`local.ts`** — `createLocalSigner` over viem's `WalletClient` + private-key EOA. EOAs can't atomically batch — `atomic: true` on multi-call batches falls back to sequential sends with a `console.warn`.
- **`namera.ts`** — `createNameraSigner` over `@namera-ai/sdk` (ZeroDev kernel account). **Execution-only**: consumes a previously-issued serialized session key + signer private key. Does NOT instantiate or require the owner key — owner keys live in encrypted keystores off-droplet, used only at session-key issuance ceremony time (TrustSwap Phase 0). **Policy-agnostic**: onchain policies (call/gas/rate/timestamp) are baked into the session key during issuance; the adapter doesn't make policy choices.
- Re-exports from `packages/resolver/src/index.ts`: `Signer`, `Batch`, `createLocalSigner`, `createNameraSigner`, and their option types.

**Notable design decision — IO is dependency-injected.** `createNameraSigner` takes `readSessionKey: () => Promise<string>` instead of a file path. This keeps the resolver free of Node-only deps (`node:fs/promises`), so browser bundlers like Next.js webpack can safely consume the resolver barrel transitively. Caller in Node typically passes `() => readFile(path, "utf-8").then(s => s.trim())`.

**Tests (4 new, 10 total):**
- local: address derivation + return shape (2 tests)
- namera: export shape + `readSessionKey` error propagation (2 tests)

End-to-end `execute(batches)` testing requires a live RPC + bundler + funded session key — deferred to TrustSwap Phase 0's live USDC→WETH broadcast on Base. Both test files include explicit comments documenting the gap.

**Closes:** SYN-52, SYN-62, SYN-63, SYN-64, SYN-65, SYN-66, SYN-67.

**Tracking:** SYN-77 (this PR).

## Test plan

- [x] `pnpm -r build` clean across resolver, cli, site
- [x] `pnpm --filter @synthesis/resolver test` — 10/10 pass (gate's 6 + wallets' 4)
- [ ] Reviewer: `pnpm install && pnpm -r build && pnpm --filter @synthesis/resolver test`
- [ ] Reviewer: spot-check `Batch` shape matches Namera SDK's verbatim (chainId, atomic, calls with bigint value)
- [ ] Reviewer: confirm `createNameraSigner` takes no Node-only deps in its imports (the `readSessionKey` DI pattern)
- [ ] Reviewer: confirm no version bump (held until PR 4)

## Up next

PR 3 (`feat/cli-gate`) adds the `ensemble gate` CLI command on top of this. Per the 4-PR serialize plan, PR 3 opens after this one merges and rebases on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)