### PR TITLE
docs(resolver): trust-policy spec + README + release 0.2.0

### DIFF
--- a/packages/cli/index.ts
+++ b/packages/cli/index.ts
@@ -47,7 +47,7 @@ import { stopSpinner } from "./utils/spinner";
 // =============================================================================
 
 const cli = Cli.create("ensemble", {
-	version: "0.1.0",
+	version: "0.2.0",
 	description: `Ensemble CLI — manage ENS names and agent identities on Ethereum.
 
 Environment Variables:

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@synthesis/cli",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Ensemble CLI — manage ENS names and agent identities on Ethereum",
   "module": "index.ts",
   "type": "module",

--- a/packages/resolver/README.md
+++ b/packages/resolver/README.md
@@ -1,0 +1,114 @@
+# `@synthesis/resolver`
+
+Trust Resolution Layer — ENS identity resolution, trust scoring, and the policy + signer primitives consumers compose against.
+
+The resolver itself is **read-only**. It walks five resolution layers (Personhood, Identity, Context, Manifest, Skill) and returns a typed `TrustProfile`. The package also exports two write-side primitives — a pure `gate()` policy function and a uniform `Signer` interface — that consuming applications wire together as `resolve → gate → sign`.
+
+## Install
+
+```bash
+pnpm add @synthesis/resolver
+```
+
+Peer deps: `viem ^2`, `zod ^3`. The Namera signer additionally requires `@namera-ai/sdk` and an ERC-4337 bundler.
+
+## Quick start
+
+### 1. Resolve + gate
+
+```typescript
+import { resolve, gate, type TrustPolicy } from "@synthesis/resolver";
+
+const profile = await resolve("emilemarcelagustin.eth");
+
+const policy: TrustPolicy = {
+  minTier: "verified",
+  requireLineage: true,
+  requireSig: true,
+  allowSelf: true,
+};
+
+const decision = gate(profile, policy);
+//   → { allow: true, reason: "all gates passed at tier full", profile, policy }
+
+if (!decision.allow) {
+  throw new Error(decision.reason);
+}
+```
+
+`gate()` is pure — no I/O, deterministic, first-match-wins across five branches. Full convention spec: [`spec/trust-policy.md`](../../spec/trust-policy.md).
+
+### 2. Sign and broadcast
+
+```typescript
+import { createLocalSigner, type Batch } from "@synthesis/resolver";
+import { base } from "viem/chains";
+
+const signer = createLocalSigner({
+  privateKey: process.env.PRIVATE_KEY as `0x${string}`,
+  chain: base,
+  rpc: "https://mainnet.base.org",
+});
+
+const batch: Batch = {
+  chainId: base.id,
+  atomic: false, // EOAs ignore atomic — see JSDoc
+  calls: [{ to: "0x…", data: "0x…", value: 0n }],
+};
+
+const txHash = await signer.execute([batch]);
+```
+
+For smart-account signing with atomic batches and onchain policy lanes (call / gas / rate-limit / timestamp), use `createNameraSigner` instead — same `Signer` interface, ZeroDev kernel account underneath. IO is dependency-injected (`readSessionKey: () => Promise<string>`) so the package stays browser-bundler-safe.
+
+## Exports
+
+| Symbol | Kind | Notes |
+|---|---|---|
+| `resolve(name, opts?)` | function | Composes the 5-layer pipeline → `TrustProfile` |
+| `resolvePersonhood`, `resolveIdentity`, `resolveContext`, `resolveManifest`, `resolveSkill` | functions | Per-layer resolvers, useful for partial reads |
+| `gate(profile, policy, callerEns?)` | function | Pure policy decision over a `TrustProfile` |
+| `TrustProfile`, `TrustTier`, `ManifestResult`, … | types + Zod schemas | Domain types from `./schema.js` |
+| `TrustPolicy`, `GateDecision` | types + Zod schemas | Policy primitive types |
+| `Signer`, `Batch` | interfaces | Uniform write-side abstraction |
+| `createLocalSigner(opts)` | function | viem-based EOA adapter |
+| `createNameraSigner(opts)` | async function | ZeroDev kernel-account adapter via `@namera-ai/sdk` |
+| `createEnsClient`, `normalizeName`, `getTextRecord`, … | functions | ENS utilities (viem-backed) |
+| `extractCid`, `fetchJsonFromIpfs`, `cidToUri`, … | functions | IPFS utilities |
+| `encodeErc7930Address`, `buildEnsip25Key`, `KNOWN_REGISTRIES` | functions | ENSIP-25 / ERC-7930 helpers |
+
+## What's new in 0.2.0
+
+- `gate()` — pure policy primitive over a `TrustProfile`. Five decision branches with normative ordering. Reference: [`spec/trust-policy.md`](../../spec/trust-policy.md).
+- `Signer` interface + `Batch` type — uniform write-side abstraction for EOA and smart-account signers.
+- `createLocalSigner` — viem `WalletClient` over a private-key EOA. Rejects wrong-chain batches.
+- `createNameraSigner` — ZeroDev kernel-account signer via `@namera-ai/sdk`. Execution-only (no owner-key requirement).
+- `Batch.nonceKey` — optional ZeroDev nonce-lane key for parallel smart-account batches.
+
+## CLI
+
+The companion `@synthesis/cli` package wraps these primitives as `ensemble gate <name>` and `ensemble trust <name>`.
+
+```bash
+pnpm add -g @synthesis/cli
+ensemble gate emilemarcelagustin.eth --min-tier verified
+# Exit 0 on allow, 1 on deny. Add --format json for machine-readable output.
+```
+
+## Tests
+
+```bash
+pnpm test
+```
+
+Covers all 6 gate decision branches plus the signer adapter constructors. End-to-end signer broadcast testing is deferred to consumers (e.g. TrustSwap Phase 0's live Base swap).
+
+## License
+
+MIT.
+
+## See also
+
+- [`spec/trust-policy.md`](../../spec/trust-policy.md) — the gate convention spec
+- [`plans/trl-policy-and-signers.md`](../../plans/trl-policy-and-signers.md) — execution plan that produced the 0.2.0 surface
+- [`plans/trust-gated-swap.md`](../../plans/trust-gated-swap.md) — first downstream consumer (trust-gated Uniswap settlement)

--- a/packages/resolver/package.json
+++ b/packages/resolver/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@synthesis/resolver",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Trust Resolution Layer — ENS identity resolution, trust scoring, and verification",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/resolver/src/policy.test.ts
+++ b/packages/resolver/src/policy.test.ts
@@ -124,6 +124,18 @@ test("denies when manifest lineage is broken", () => {
   assert.match(decision.reason, /manifest lineage broken at v2/);
 });
 
+test("applies schema defaults when policy fields are omitted (runtime safety)", () => {
+  const profile = makeProfile({ trustScore: "registered" });
+  // Partial policy — would happen with JSON inputs, JS callers, or MCP
+  // params where TypeScript can't enforce required fields. The spec
+  // promises defaults; gate() must apply them.
+  const partialPolicy = {} as unknown as TrustPolicy;
+  const decision = gate(profile, partialPolicy);
+  // Default minTier is "verified", so registered should be denied.
+  assert.equal(decision.allow, false);
+  assert.match(decision.reason, /tier registered below required verified/);
+});
+
 test("allows when all gates pass", () => {
   const profile = makeProfile({
     ensName: "alice.eth",

--- a/packages/resolver/src/policy.ts
+++ b/packages/resolver/src/policy.ts
@@ -35,6 +35,14 @@ export function gate(
   policy: TrustPolicy,
   callerEns?: string,
 ): GateDecision {
+  // Normalize through the schema so missing fields fall back to documented
+  // defaults at runtime (the spec contract). TypeScript callers already get
+  // required-field enforcement, but JSON / JS / MCP-tool callers can pass
+  // partial inputs — without this, undefined `minTier` would silently skip
+  // the tier check, etc. Echo the ORIGINAL `policy` in the decision so audit
+  // logs see what the caller actually passed.
+  const p = TrustPolicySchema.parse(policy);
+
   // 1. Deny: self disallowed.
   // When allowSelf is false, callerEns is REQUIRED — without it, the gate
   // can't determine self vs not-self and a missing flag would silently
@@ -45,7 +53,7 @@ export function gate(
   // case-insensitive per ENSIP-15, so a raw === would let "Alice.eth"
   // bypass an allowSelf:false gate against a profile resolved from
   // "alice.eth".
-  if (!policy.allowSelf) {
+  if (!p.allowSelf) {
     if (!callerEns) {
       return {
         allow: false,
@@ -68,10 +76,10 @@ export function gate(
   }
 
   // 2. Deny: tier below minimum
-  if (tierRank(profile.trustScore) < tierRank(policy.minTier)) {
+  if (tierRank(profile.trustScore) < tierRank(p.minTier)) {
     return {
       allow: false,
-      reason: `tier ${profile.trustScore} below required ${policy.minTier}`,
+      reason: `tier ${profile.trustScore} below required ${p.minTier}`,
       profile,
       policy,
     };
@@ -79,7 +87,7 @@ export function gate(
 
   // 3. Deny: signature invalid (only when manifest was found)
   if (
-    policy.requireSig &&
+    p.requireSig &&
     profile.manifest.found &&
     !profile.manifest.signatureValid
   ) {
@@ -92,7 +100,7 @@ export function gate(
   }
 
   // 4. Deny: lineage broken
-  if (policy.requireLineage && !profile.manifest.lineageIntact) {
+  if (p.requireLineage && !profile.manifest.lineageIntact) {
     return {
       allow: false,
       reason: `manifest lineage broken at v${profile.manifest.lineageDepth}`,

--- a/spec/trust-policy.md
+++ b/spec/trust-policy.md
@@ -1,0 +1,123 @@
+# Trust Policy + Gate Convention (Draft)
+
+A composable convention for turning a `TrustProfile` (the output of any TRL-style resolver) into a typed `allow / deny` decision against a configurable policy. Reference implementation: [`@synthesis/resolver`](../packages/resolver) (`gate()` and `TrustPolicy`).
+
+## Abstract
+
+This draft standardizes a minimal, deterministic **policy + gate function** that maps `(profile, policy) → decision`. The goal is a stable surface that any consumer of trust resolution data — CLIs, server actions, MCP tools, long-lived agents — can compose against without each app re-inventing the same five decision branches. The function is pure (no I/O), so it is unit-testable in isolation and safely cacheable.
+
+## Motivation
+
+A `TrustProfile` is a noun. Acting on it requires turning it into a verb — a decision. Without a shared convention, every downstream app reinvents:
+
+1. *What "trusted enough" means* (which tier? lineage required? signature required?)
+2. *How to express the decision* (boolean? object? error?)
+3. *How to communicate refusal* (reason string format, error semantics)
+
+This draft fixes those three questions with the smallest viable surface, so different apps can substitute trust providers, swap signers, or compose policies without breaking integrators that consume the decision.
+
+## Specification
+
+The keywords MUST, SHOULD, MAY follow [RFC 2119](https://www.rfc-editor.org/rfc/rfc2119).
+
+### 1. The `TrustPolicy` schema (normative)
+
+| Field | Type | Default | Semantics |
+|---|---|---|---|
+| `minTier` | `TrustTier` enum | `"verified"` | Minimum trust tier required. `none < registered < discoverable < verified < full`. |
+| `requireLineage` | `boolean` | `true` | When true, profile MUST have `manifest.lineageIntact === true` to allow. |
+| `requireSig` | `boolean` | `true` | When true AND a manifest exists, `manifest.signatureValid` MUST be true. |
+| `allowSelf` | `boolean` | `true` | When false, the caller MUST NOT be the same ENS name as the resolved profile. |
+
+Implementations MUST treat undefined fields as the defaults above. The defaults represent the minimum-safe policy — adopters opt out of checks explicitly.
+
+### 2. The `GateDecision` shape (normative)
+
+```typescript
+interface GateDecision {
+  allow: boolean;     // the verdict
+  reason: string;     // human-readable; canonical strings below
+  profile: TrustProfile;  // the input profile (echoed for auditability)
+  policy: TrustPolicy;    // the input policy (echoed for auditability)
+}
+```
+
+Echoing `profile` and `policy` MUST happen even on deny — the decision is self-describing for after-the-fact audit logs without requiring the auditor to re-resolve.
+
+### 3. The `gate` function contract (normative)
+
+```typescript
+function gate(
+  profile: TrustProfile,
+  policy: TrustPolicy,
+  callerEns?: string,
+): GateDecision;
+```
+
+Implementations MUST:
+
+- Be **pure** — no I/O, no async, no side effects, deterministic for identical inputs.
+- Apply branches in the order specified in §4 (first-match-wins).
+- Echo `profile` and `policy` verbatim in the returned `GateDecision`.
+
+Implementations MUST NOT throw on valid input. Invalid input (e.g. a malformed `callerEns` that fails ENS normalization) MAY throw.
+
+### 4. Decision branches (normative — first match wins)
+
+| Order | Branch | Condition | `reason` |
+|---|---|---|---|
+| 1 | Deny: missing caller identity | `!policy.allowSelf && !callerEns` | `"self-resolution check requires callerEns when allowSelf is false"` |
+| 2 | Deny: self disallowed | `!policy.allowSelf && normalize(callerEns) === normalize(profile.ensName)` | `"self-resolution not permitted by policy"` |
+| 3 | Deny: tier below | `tierRank(profile.trustScore) < tierRank(policy.minTier)` | `` `tier ${actual} below required ${minTier}` `` |
+| 4 | Deny: signature invalid | `policy.requireSig && profile.manifest.found && !profile.manifest.signatureValid` | `"manifest signature does not match current ENS owner"` |
+| 5 | Deny: lineage broken | `policy.requireLineage && !profile.manifest.lineageIntact` | `` `manifest lineage broken at v${depth}` `` |
+| 6 | Allow | otherwise | `` `all gates passed at tier ${tier}` `` |
+
+**Notes:**
+- Branch 1 is **fail-closed**. When a policy opts out of `allowSelf`, the gate cannot determine self-equality without `callerEns` — silently skipping the check would bypass an explicitly-requested safety control.
+- Branch 2 normalizes both names per [ENSIP-15](https://docs.ens.domains/ensip/15) before equality. Without normalization, `Alice.eth` would bypass an `allowSelf: false` gate against a profile resolved from `alice.eth`.
+- Branch 4 guards on `manifest.found` so profiles without a manifest don't fail the signature check vacuously. Branch 5 (lineage) does not — `lineageIntact` defaults to `false` for missing manifests by convention, so requiring lineage requires *having* a manifest.
+
+### 5. Tier ranking (normative)
+
+```
+none = 0
+registered = 1
+discoverable = 2
+verified = 3
+full = 4
+```
+
+Strictly ordered. The set is closed — implementations MUST NOT introduce new tiers without a spec revision.
+
+### 6. CLI exit-code convention (recommended)
+
+CLI consumers of `gate()` SHOULD adopt:
+
+| Exit code | Meaning |
+|---|---|
+| `0` | `decision.allow === true` |
+| `1` | `decision.allow === false` |
+
+This lets shell pipelines branch on a gate decision without parsing output. Reference implementation: `ensemble gate <name>` in `@synthesis/cli`.
+
+## Reference implementation
+
+- **Library:** [`@synthesis/resolver`](../packages/resolver) — exports `gate`, `TrustPolicy`, `TrustPolicySchema`, `GateDecision`, `GateDecisionSchema`. ~90 LoC + 12 unit tests.
+- **CLI:** `ensemble gate <ens>` in [`@synthesis/cli`](../packages/cli) — pretty-prints the decision, exits per §6, supports `--format json` for machine-readable output.
+
+## Adoption
+
+Trust providers other than the synthesis Trust Resolution Layer MAY adopt this convention by producing a `TrustProfile`-shaped object and reusing the same `gate()` semantics. The decision shape and branch order are independent of *how* a profile was resolved — different providers (TRL, Signet, future personhood + reputation systems) can compose against the same policy primitive.
+
+Application authors building on TRL — e.g. trust-gated payment tools, agent-to-agent coordination, gated bridges — SHOULD use this primitive directly rather than implementing per-app gating logic. A single canonical implementation prevents drift across the ecosystem.
+
+## Status
+
+Draft. Lives in this repo while the reference implementation matures. If adoption extends beyond the Synthesis project, a future revision MAY pitch this as an ENSIP.
+
+## See also
+
+- `plans/trl-policy-and-signers.md` — execution plan that produced the reference implementation
+- `plans/trust-gated-swap.md` — first downstream consumer (trust-gated Uniswap settlement)
+- [ENSIP-15: ENS Name Normalization](https://docs.ens.domains/ensip/15)


### PR DESCRIPTION
## Summary

**Final of four serialized PRs landing Layer A** — TRL Policy + Signers (plan: `plans/trl-policy-and-signers.md`). Wraps Phase A.4: spec doc, README, and the `0.2.0` version bump that releases the complete gate + Signer + CLI surface as a single semver.

| | Shipped via |
|---|---|
| `gate()` primitive + tests | PR #27 |
| `Signer` interface + local + namera adapters | PR #28 |
| `ensemble gate` CLI command | PR #29 |
| Spec + README + 0.2.0 release (this) | PR #30 |

**Adds:**

- **`spec/trust-policy.md`** — ENSIP-style draft of the gate convention. Documents `TrustPolicy` schema, `GateDecision` shape, the **six-branch decision contract** (incl. the fail-closed missing-`callerEns` guard from PR #29's Codex P1), tier ranking, and the 0/1 CLI exit-code convention. Pitched as a future ENSIP if adoption extends beyond synthesis.
- **`packages/resolver/README.md` (NEW)** — install + peer deps, two quick-start examples (resolve+gate, signer+execute), full exports table, what's-new-in-0.2.0 section, links back to the spec and execution plans.

**Bumps:**
- `@synthesis/resolver` `0.1.0 → 0.2.0`
- `@synthesis/cli` `0.1.0 → 0.2.0`

Both are minor bumps (additive, no breaking changes to the existing 0.1.0 surface).

**Closes:** SYN-54, SYN-72, SYN-73, SYN-74.

**Tracking:** SYN-75 (this PR).

## Test plan

- [x] `pnpm -r build` clean across resolver, cli, site
- [x] `pnpm --filter @synthesis/resolver test` — 12/12 pass
- [ ] Reviewer: read `spec/trust-policy.md` end-to-end and confirm the documented decision branches match the resolver implementation
- [ ] Reviewer: skim `packages/resolver/README.md` quick-start examples for accuracy
- [ ] Reviewer: confirm both `package.json` versions are `0.2.0`

## What ships when this merges

Layer A is **done**. `@synthesis/resolver@0.2.0` and `@synthesis/cli@0.2.0` carry:
- The original 0.1.0 read-only resolver surface
- `gate()` policy primitive + `TrustPolicy` / `GateDecision` schemas
- `Signer` interface + `Batch` type + `createLocalSigner` + `createNameraSigner`
- `ensemble gate <name>` CLI command
- Browser-bundler-safe (Next.js webpack consumes the resolver barrel cleanly via the dependency-injected `readSessionKey` pattern in `createNameraSigner`)

This unblocks the next stream of work: **TrustSwap Phase 0** (`plans/trust-gated-swap.md`) — the first downstream application built on these primitives. TrustSwap consumes `gate`, `Signer`, and the adapter factories from this package.

🤖 Generated with [Claude Code](https://claude.com/claude-code)