### PR TITLE
fix(cli): destructure normalizeEnsName in context set

### DIFF
--- a/packages/cli/commands/context.ts
+++ b/packages/cli/commands/context.ts
@@ -69,19 +69,19 @@ export async function contextSet(options: ContextSetOptions) {
     }
   }
 
-  const normalized = normalizeEnsName(name);
-  const resolverAddress = await getResolver(normalized, network);
+  const { node, fullName } = normalizeEnsName(name, network);
+  const resolverAddress = await getResolver(node, network);
 
   if (!resolverAddress) {
-    console.error(colors.red(`No resolver found for ${name}`));
+    console.error(colors.red(`No resolver found for ${fullName}`));
     return;
   }
 
-  startSpinner(`Setting agent-context on ${colors.cyan(name)}...`);
+  startSpinner(`Setting agent-context on ${colors.cyan(fullName)}...`);
 
   try {
     await setTextRecordOnChain(
-      normalized,
+      node,
       "agent-context",
       value,
       resolverAddress,
@@ -91,7 +91,7 @@ export async function contextSet(options: ContextSetOptions) {
     );
     stopSpinner();
 
-    console.log(colors.green("✓") + ` agent-context set on ${colors.cyan(name)}`);
+    console.log(colors.green("✓") + ` agent-context set on ${colors.cyan(fullName)}`);
     console.log(`  ${colors.blue("Value:")} ${value.length > 80 ? value.slice(0, 80) + "..." : value}`);
   } catch (error) {
     stopSpinner();


### PR DESCRIPTION
## Summary

- `contextSet` was passing the whole `normalizeEnsName(name)` return object (`{ label, fullName, node }`) as the bytes32 `node` argument to `getResolver` and `setTextRecordOnChain`. Destructure `{ node, fullName }` and pass `node` correctly.
- Use `fullName` in display copy.
- Pass `network` into `normalizeEnsName` so the resolved name is consistent with the rest of the call.

## Why

`getResolver` and `setTextRecordOnChain` are typed `node: \`0x\${string}\``. With the object passed in, modern viem rejects the malformed hex and reverts; older viem stringifies to `"[object Object]"` and silently writes the agent-context record under a junk namehash.

## Audit

Swept every `normalizeEnsName` call-site in `packages/cli`. Two patterns exist:

1. Destructure (`const { fullName, node } = normalizeEnsName(...)`) — used in `agent.ts:211`, `verify.ts:35`, `utils.ts:37/81`, `edit.ts:74/234/339`, `register.ts:128`, `resolve.ts:98`, `available.ts:33`, `transfer.ts:66`, `renew.ts:84`. Correct.
2. Property access (`const normalized = normalizeEnsName(...); normalized.node`) — used in `profile.ts:86/90`. Verbose but correct.

`context.ts:72` was the only site passing the whole object to a function expecting bytes32. No other instances.

## Why didn't tsc catch this?

`tsconfig.json` already has `strict: true`, and `tsc --noEmit` does flag the type mismatch (verified locally). But the CLI's build script runs only `tsup` (esbuild), which doesn't typecheck. So the regression compiled and shipped as a runtime `[object Object]`. Wiring `tsc --noEmit` into CI would be the right follow-up but is out of scope here — `agent.ts` and `manifest.ts` have pre-existing typecheck failures from viem/SDK drift that need their own cleanup pass first.

## Test plan

- [x] `pnpm -F @synthesis/cli build` clean
- [x] `tsc --noEmit` shows zero errors in `context.ts` (pre-existing errors in `agent.ts`/`manifest.ts` are unrelated)
- [ ] Sepolia smoke: `ensemble context set test.eth '{\"role\":\"demo\"}'` writes successfully, and `ensemble edit txt test.eth agent-context` reads back the same value (proves the namehash is correct)

## Closes

Closes #33.

🤖 Generated with [Claude Code](https://claude.com/claude-code)