### PR TITLE
chore(infra): wire tsc --noEmit into CI; fix pre-existing typecheck failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,40 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+jobs:
+  check:
+    name: Typecheck, build, test
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install
+        run: pnpm install --frozen-lockfile
+
+      - name: Build resolver
+        run: pnpm --filter @synthesis/resolver build
+
+      - name: Typecheck
+        run: pnpm typecheck
+
+      - name: Test resolver
+        run: pnpm --filter @synthesis/resolver test
+
+      - name: Build CLI
+        run: pnpm --filter @synthesis/cli build

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "deploy:vercel": "pnpm build:resolver && pnpm build:site",
     "deploy:ipfs": "pnpm build:resolver && cd packages/site && NEXT_OUTPUT=export next build && cd ../.. && npx omnipin deploy packages/site/out",
     "pin": "npx omnipin pin",
+    "typecheck": "pnpm --filter @synthesis/resolver typecheck && pnpm --filter @synthesis/cli typecheck",
     "lint": "pnpm -r lint",
     "format": "pnpm -r format"
   },

--- a/packages/cli/commands/agent.ts
+++ b/packages/cli/commands/agent.ts
@@ -113,6 +113,8 @@ export async function registerAgent(options: AgentRegisterOptions) {
 		}
 
 		const txHash = await wallet.writeContract({
+			account: wallet.account ?? null,
+			chain: wallet.chain,
 			address: agentChain.identityRegistry8004,
 			abi: IDENTITY_REGISTRY_8004_ABI,
 			functionName: "register",

--- a/packages/cli/commands/manifest.ts
+++ b/packages/cli/commands/manifest.ts
@@ -130,7 +130,7 @@ export async function manifestPin(options: ManifestPinOptions) {
   try {
     const { PinataSDK } = await import("pinata");
     const pinata = new PinataSDK({ pinataJwt, pinataGateway: "" });
-    const result = await pinata.upload.public.json(JSON.parse(content));
+    const result = await pinata.upload.json(JSON.parse(content));
     stopSpinner();
 
     console.log(colors.green("✓") + " Pinned to IPFS");

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -19,9 +19,10 @@
     "format": "npx @biomejs/biome format --write ."
   },
   "devDependencies": {
-    "typescript": "^5.8.3",
+    "@types/node": "^25.6.0",
     "tsup": "^8.5.1",
-    "tsx": "^4.20.6"
+    "tsx": "^4.20.6",
+    "typescript": "^5.8.3"
   },
   "dependencies": {
     "@ledgerhq/hw-app-eth": "^7.2.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -12,6 +12,7 @@
   ],
   "scripts": {
     "build": "tsup index.ts --format esm --dts --outDir dist",
+    "typecheck": "tsc --noEmit",
     "dev": "tsx index.ts",
     "start": "node dist/index.js",
     "lint": "npx @biomejs/biome lint --write .",

--- a/packages/resolver/package.json
+++ b/packages/resolver/package.json
@@ -16,6 +16,7 @@
   ],
   "scripts": {
     "build": "tsup src/index.ts --format esm --dts --outDir dist",
+    "typecheck": "tsc --noEmit",
     "dev": "tsx src/index.ts",
     "lint": "npx @biomejs/biome lint --write .",
     "format": "npx @biomejs/biome format --write .",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -48,6 +48,9 @@ importers:
         specifier: ^3.24.2
         version: 3.25.76
     devDependencies:
+      '@types/node':
+        specifier: ^25.6.0
+        version: 25.6.0
       tsup:
         specifier: ^8.5.1
         version: 8.5.1(jiti@2.6.1)(postcss@8.5.8)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2)
@@ -1052,6 +1055,9 @@ packages:
 
   '@types/node@22.7.5':
     resolution: {integrity: sha512-jML7s2NAzMWc//QSJ1a3prpk78cOPchGvXJsC3C6R6PSMoooztvRVQEz89gmBTBY1SPMaqo5teB4uNHPdetShQ==}
+
+  '@types/node@25.6.0':
+    resolution: {integrity: sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==}
 
   '@types/react-dom@19.2.3':
     resolution: {integrity: sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==}
@@ -2277,6 +2283,9 @@ packages:
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
 
+  undici-types@7.19.2:
+    resolution: {integrity: sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==}
+
   unpipe@1.0.0:
     resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
     engines: {node: '>= 0.8'}
@@ -3254,6 +3263,10 @@ snapshots:
   '@types/node@22.7.5':
     dependencies:
       undici-types: 6.19.8
+
+  '@types/node@25.6.0':
+    dependencies:
+      undici-types: 7.19.2
 
   '@types/react-dom@19.2.3(@types/react@19.2.14)':
     dependencies:
@@ -4528,6 +4541,8 @@ snapshots:
   undici-types@6.19.8: {}
 
   undici-types@6.21.0: {}
+
+  undici-types@7.19.2: {}
 
   unpipe@1.0.0: {}
 


### PR DESCRIPTION
## Summary

- Add a `typecheck` script (`tsc --noEmit`) to `@synthesis/resolver` and `@synthesis/cli`, plus a root-level aggregator.
- Add `.github/workflows/ci.yml` — the repo's first CI workflow. Runs install → resolver build → typecheck → resolver tests → CLI build on every PR to main.
- Fix two pre-existing failures that were blocking the gate:
  - `agent.ts:115` — viem's `WriteContractParameters` requires `chain`. Pass `chain: wallet.chain` and `account: wallet.account ?? null` so the wallet's bound chain flows through explicitly.
  - `manifest.ts:133` — Pinata SDK 1.x removed the `upload.public.json` accessor; use `upload.json` directly. Public/private moved into account-level config in 1.x, and `UploadResponse.cid` is unchanged so no downstream impact.

## Why

`packages/cli/tsconfig.json` already has `strict: true`, but `tsup` (esbuild) doesn't typecheck during build. So bugs like #33 (passing a `normalizeEnsName` object as a bytes32 `node`) compiled cleanly and shipped as runtime `[object Object]`. Local `tsc --noEmit` flagged that exact mismatch — wiring it into CI closes the gap.

## Verification

```
$ pnpm typecheck
> @synthesis/resolver typecheck → exit 0
> @synthesis/cli typecheck → exit 0
```

A regression that re-introduces #33 (e.g. dropping the destructure in `context.ts`) would now fail CI:

```
commands/context.ts:73:46 - error TS2345: Argument of type '{ label: string; fullName: string; node: \`0x\${string}\` }' is not assignable to parameter of type \`0x\${string}\`.
```

## Notes

- This is the first CI in the repo; conservative scope on purpose. Lint and site builds are deliberately not gated yet — the resolver/CLI typecheck + tests gate is the immediate need.
- Node 22 / pnpm 9 chosen to match local dev and `engines` if/when added.
- Resolver build runs before typecheck because `@synthesis/cli` consumes `@synthesis/resolver` from `dist/`.

## Test plan

- [x] `pnpm typecheck` exits 0
- [x] `pnpm --filter @synthesis/resolver test` exits 0 (17/17)
- [x] `pnpm --filter @synthesis/cli build` exits 0
- [ ] Workflow runs green on this PR

## Closes

Closes #37.

🤖 Generated with [Claude Code](https://claude.com/claude-code)