### PR TITLE
fix(cli): re-land agent-ids index write (lost in PR #34 squash)

### DIFF
--- a/packages/cli/commands/agent.ts
+++ b/packages/cli/commands/agent.ts
@@ -11,7 +11,7 @@ import {
 	stopSpinner,
 	normalizeEnsName,
 	getResolver,
-	getTextRecord,
+	getTextRecordStrict,
 	setTextRecordOnChain,
 	getSignerAddress,
 	getSignerAddressAsync,
@@ -273,16 +273,51 @@ export async function linkAgent(options: AgentLinkOptions) {
 		// ENS exposes no text-record enumeration, so the resolver reads the
 		// `agent-ids` JSON array to know which IDs to look up under the
 		// ENSIP-25 prefix. Without this write the link is invisible.
-		const existingRaw = await getTextRecord(resolver, node, "agent-ids", ensNetwork);
+		//
+		// Use the strict reader: a transient RPC failure here is NOT the same
+		// as "no record exists". Treating it as empty would let us silently
+		// overwrite a populated `agent-ids` array with `[<this id>]` and
+		// erase previously linked agents. Surface the error and bail.
+		let existingRaw: string | null;
+		try {
+			existingRaw = await getTextRecordStrict(resolver, node, "agent-ids", ensNetwork);
+		} catch (readErr) {
+			console.error(
+				colors.red(
+					`✗ Failed to read existing agent-ids before update: ${(readErr as Error).message}`,
+				),
+			);
+			console.error(
+				colors.yellow(
+					`  ENSIP-25 record is set, but agent-ids was NOT updated. Re-run \`ensemble agent link ${fullName} ${agentId}\` once the RPC recovers.`,
+				),
+			);
+			return;
+		}
+
 		let ids: string[] = [];
 		if (existingRaw) {
 			try {
 				const parsed = JSON.parse(existingRaw);
 				if (Array.isArray(parsed)) {
 					ids = parsed.filter((x): x is string => typeof x === "string");
+				} else {
+					// Non-array JSON is unexpected and would be silently overwritten;
+					// refuse instead and let the user inspect/fix.
+					console.error(
+						colors.red(
+							`✗ agent-ids on ${fullName} is not a JSON array (got: ${existingRaw.slice(0, 80)}). Refusing to overwrite. Inspect with \`ensemble edit txt ${fullName} agent-ids\`.`,
+						),
+					);
+					return;
 				}
 			} catch {
-				// Malformed value — overwrite with a clean array containing just the new id.
+				console.error(
+					colors.red(
+						`✗ agent-ids on ${fullName} is not valid JSON (got: ${existingRaw.slice(0, 80)}). Refusing to overwrite. Inspect with \`ensemble edit txt ${fullName} agent-ids\`.`,
+					),
+				);
+				return;
 			}
 		}
 

--- a/packages/cli/commands/agent.ts
+++ b/packages/cli/commands/agent.ts
@@ -11,6 +11,7 @@ import {
 	stopSpinner,
 	normalizeEnsName,
 	getResolver,
+	getTextRecord,
 	setTextRecordOnChain,
 	getSignerAddress,
 	getSignerAddressAsync,
@@ -222,6 +223,9 @@ export async function linkAgent(options: AgentLinkOptions) {
 		console.log(colors.blue(`Linking agent #${agentId} to ${fullName}...`));
 		console.log(colors.dim(`  ENSIP-25 key: ${ensip25Key}`));
 		console.log(colors.dim(`  Value: "1" (linked)`));
+		console.log(
+			colors.dim(`  This requires up to two transactions (ENSIP-25 record + agent-ids index).`),
+		);
 
 		// Get resolver
 		const resolver = await getResolver(node, ensNetwork);
@@ -257,12 +261,69 @@ export async function linkAgent(options: AgentLinkOptions) {
 		});
 		stopSpinner();
 
-		if (receipt.status === "success") {
-			console.log(colors.green(`✓ Agent #${agentId} linked to ${fullName}`));
-			console.log(`  ${colors.blue("Explorer:")} ${config.explorerUrl}/tx/${txHash}`);
-		} else {
+		if (receipt.status !== "success") {
 			console.error(colors.red("✗ Transaction reverted"));
+			return;
 		}
+
+		console.log(colors.green(`✓ ENSIP-25 record set`));
+		console.log(`  ${colors.blue("Explorer:")} ${config.explorerUrl}/tx/${txHash}`);
+
+		// Update the agent-ids index so the resolver can discover this agent.
+		// ENS exposes no text-record enumeration, so the resolver reads the
+		// `agent-ids` JSON array to know which IDs to look up under the
+		// ENSIP-25 prefix. Without this write the link is invisible.
+		const existingRaw = await getTextRecord(resolver, node, "agent-ids", ensNetwork);
+		let ids: string[] = [];
+		if (existingRaw) {
+			try {
+				const parsed = JSON.parse(existingRaw);
+				if (Array.isArray(parsed)) {
+					ids = parsed.filter((x): x is string => typeof x === "string");
+				}
+			} catch {
+				// Malformed value — overwrite with a clean array containing just the new id.
+			}
+		}
+
+		if (ids.includes(agentId)) {
+			console.log(colors.dim(`  agent-ids already contains ${agentId}, skipping index update`));
+		} else {
+			if (useLedger) {
+				console.log(
+					colors.yellow("Please confirm the second transaction on your Ledger device..."),
+				);
+			}
+			startSpinner("Updating agent-ids index...");
+			const idsTxHash = await setTextRecordOnChain(
+				node,
+				"agent-ids",
+				JSON.stringify([...ids, agentId]),
+				resolver,
+				ensNetwork,
+				useLedger,
+				accountIndex,
+			);
+			const idsReceipt = await client.waitForTransactionReceipt({
+				hash: idsTxHash,
+				confirmations: 2,
+			});
+			stopSpinner();
+
+			if (idsReceipt.status !== "success") {
+				console.error(
+					colors.red(
+						`✗ agent-ids update reverted. ENSIP-25 record is set but the resolver won't discover it until you re-run \`ensemble agent link\` or write agent-ids manually.`,
+					),
+				);
+				return;
+			}
+
+			console.log(colors.green(`✓ agent-ids updated`));
+			console.log(`  ${colors.blue("Explorer:")} ${config.explorerUrl}/tx/${idsTxHash}`);
+		}
+
+		console.log(colors.green(`✓ Agent #${agentId} linked to ${fullName}`));
 	} catch (error) {
 		stopSpinner();
 		const e = error as Error;

--- a/packages/cli/utils/contracts.ts
+++ b/packages/cli/utils/contracts.ts
@@ -568,6 +568,28 @@ export async function getTextRecord(
 }
 
 /**
+ * Strict read of a text record. Returns null only when the resolver returns
+ * an empty string ("not set"). Any RPC / contract error is thrown so the
+ * caller can distinguish "absent" from "read failed" — important before
+ * writing back values that should preserve prior content.
+ */
+export async function getTextRecordStrict(
+	resolverAddress: Address,
+	node: `0x${string}`,
+	key: string,
+	network?: string,
+): Promise<string | null> {
+	const client = getPublicClient(network);
+	const value = await client.readContract({
+		address: resolverAddress,
+		abi: RESOLVER_ABI,
+		functionName: "text",
+		args: [node, key],
+	});
+	return value || null;
+}
+
+/**
  * Get contenthash from resolver
  */
 export async function getContenthash(


### PR DESCRIPTION
## Summary

Re-lands the two commits from PR #35 that were lost when PR #34 was squash-merged into main. Cherry-picks `01a0009` + `32aa6a7` cleanly onto current `main`.

Closes #39. Re-closes #32 (which #35 was supposed to close).

## Why this is needed

PR #35 was opened with base `fix/cli-ensip25-encoder-unify` (stacked on PR #34) and GitHub marked it MERGED at 2026-05-02 21:23 UTC — but only into the #34 branch. PR #34 was then squash-merged into main, collapsing only the encoder commit (`22c1a6b`) and dropping the stacked agent-ids commits.

Symptom on mainnet (reproduced 2026-05-02 ~21:50 UTC against `daemon.trustrust.eth`):
- `ensemble agent register --link true` only emits one setText (the ENSIP-25 record)
- `agent-ids` text record stays empty
- `resolveIdentity(name)` returns `verified: false` because `discoverAgentIds` reads `agent-ids` and gets `[]`

## What's in this PR

Two commits, identical to the ones the original PR #35 reviewed:

1. `fix(cli): write agent-ids index alongside ENSIP-25 record on link` — after the ENSIP-25 record confirms, read existing `agent-ids`, append the new id if missing, write back. Idempotent. Banner warns up front about two transactions; Ledger prompt repeats for the second write.
2. `fix(cli): treat agent-ids read failure as fatal, not as empty` — addresses the P1 data-loss path Codex flagged on #35: a transient RPC error during the read would otherwise be indistinguishable from "record doesn't exist" and the subsequent write would clobber any previously indexed agents. Adds `getTextRecordStrict` and refuses to overwrite non-JSON / non-array values.

## Verification

- `pnpm --filter @synthesis/cli exec tsc --noEmit` — clean
- Cherry-pick was a clean 3-way merge in `packages/cli/commands/agent.ts` (the conflict was just adjacency to landed code, semantics unchanged)
- CI typecheck gate from #38 will catch any regression

## Follow-up (not in this PR)

The handoff doc `SYNTHESIS-CLI-FIXES.md` lives in the consumer/trust-swap repo, not here — flagged for the reporter on #39 to correct there once this lands.

## Test plan

- [ ] Re-run `ensemble agent register daemon.trustrust.eth --link true --chain base` after merge, confirm two transactions, confirm `cast call ... text(<node>, "agent-ids")` returns the JSON array
- [ ] Confirm `resolveIdentity("daemon.trustrust.eth")` returns `verified: true`
- [ ] Confirm A2A peer-fulfillment trust-swap demo no longer fails with "broken signature"

🤖 Generated with [Claude Code](https://claude.com/claude-code)