### PR TITLE
fix(resolver): verify manifest signature against ENS registry owner, not addr()

### DIFF
--- a/packages/resolver/src/layers/manifest.ts
+++ b/packages/resolver/src/layers/manifest.ts
@@ -14,7 +14,7 @@
 import { verifyMessage, type PublicClient } from "viem";
 import type { AgentManifest, ManifestResult } from "../schema.js";
 import { AgentManifestSchema } from "../schema.js";
-import { createEnsClient, getTextRecord, resolveAddress } from "../utils/ens.js";
+import { createEnsClient, getOwner, getTextRecord } from "../utils/ens.js";
 import { extractCid, fetchFromIpfs } from "../utils/ipfs.js";
 
 export interface ResolveManifestOptions {
@@ -129,6 +129,13 @@ async function fetchManifest(
  * 1. ensName matches the root name being resolved
  * 2. version matches the version identifier
  * 3. Signature is valid against the current ENS owner
+ *
+ * The verifier address is the **registry owner** (unwrapped if the name is
+ * held by the NameWrapper) — not `addr()`. `addr()` is the payment record
+ * and may be a smart contract that does not control the name; the manifest
+ * authority is whoever owns the name on the registry. For names owned by
+ * smart-contract wallets (e.g. Safe), `verifyMessage` falls through to the
+ * ERC-1271 path automatically.
  */
 async function verifyManifestSignature(
   client: PublicClient,
@@ -142,8 +149,8 @@ async function verifyManifestSignature(
   // Verify version matches
   if (manifest.version !== expectedVersion) return false;
 
-  // Get the current ENS owner address
-  const ownerAddress = await resolveAddress(client, ensName);
+  // Get the current ENS registry owner (unwrap NameWrapper if needed)
+  const ownerAddress = await getOwner(client, ensName);
   if (!ownerAddress) return false;
 
   // Build canonical bytes (sorted keys, no whitespace)

--- a/packages/resolver/src/utils/ens.ts
+++ b/packages/resolver/src/utils/ens.ts
@@ -8,6 +8,8 @@
 import {
   createPublicClient,
   http,
+  namehash,
+  zeroAddress,
   type Address,
   type PublicClient,
 } from "viem";
@@ -15,6 +17,35 @@ import { normalize } from "viem/ens";
 import { mainnet } from "viem/chains";
 
 const DEFAULT_RPC = "https://eth.drpc.org";
+
+// Mainnet ENS Registry (deterministic across networks that use the canonical deployment)
+const ENS_REGISTRY_ADDRESS: Address =
+  "0x00000000000C2E074eC69A0dFb2997BA6C7d2e1e";
+
+// Mainnet NameWrapper. Sepolia uses 0x0635513f179D50A207757E05759CbD106d7dFcE8;
+// the resolver is mainnet-only today, so we only check the mainnet address here.
+const NAME_WRAPPER_ADDRESS: Address =
+  "0xD4416b13d2b3a9aBae7AcD5D6C2BbDBE25686401";
+
+const REGISTRY_ABI = [
+  {
+    type: "function",
+    name: "owner",
+    stateMutability: "view",
+    inputs: [{ name: "node", type: "bytes32" }],
+    outputs: [{ name: "", type: "address" }],
+  },
+] as const;
+
+const NAME_WRAPPER_ABI = [
+  {
+    type: "function",
+    name: "ownerOf",
+    stateMutability: "view",
+    inputs: [{ name: "id", type: "uint256" }],
+    outputs: [{ name: "", type: "address" }],
+  },
+] as const;
 
 /**
  * Create a public client configured for ENS resolution on mainnet.
@@ -112,20 +143,44 @@ export async function resolveAddress(
 }
 
 /**
- * Get the owner (registrant) address of an ENS name.
+ * Get the registry owner of an ENS name — the address that controls the
+ * name and is authorized to sign records on its behalf.
  *
- * Uses the ENS registry's owner() function.
- * Returns null if the name doesn't exist.
+ * Reads `Registry.owner(node)`. If the registry owner is the NameWrapper,
+ * unwraps via `NameWrapper.ownerOf(uint256(node))` to return the true owner.
+ *
+ * This is the right address for verifying record signatures (AIP manifests,
+ * ENSIP-25 links, etc.) — distinct from `addr()`, which is the payment
+ * address and may be a smart contract that does not control the name.
+ *
+ * Returns null if the name is unowned or the lookup fails.
  */
 export async function getOwner(
   client: PublicClient,
   name: string,
 ): Promise<Address | null> {
   try {
-    // viem doesn't have a direct getEnsOwner, but we can resolve
-    // the name to check it exists, then use the registry
-    const address = await resolveAddress(client, name);
-    return address;
+    const node = namehash(normalizeName(name));
+    const registryOwner = (await client.readContract({
+      address: ENS_REGISTRY_ADDRESS,
+      abi: REGISTRY_ABI,
+      functionName: "owner",
+      args: [node],
+    })) as Address;
+
+    if (registryOwner === zeroAddress) return null;
+
+    if (registryOwner.toLowerCase() === NAME_WRAPPER_ADDRESS.toLowerCase()) {
+      const wrappedOwner = (await client.readContract({
+        address: NAME_WRAPPER_ADDRESS,
+        abi: NAME_WRAPPER_ABI,
+        functionName: "ownerOf",
+        args: [BigInt(node)],
+      })) as Address;
+      return wrappedOwner === zeroAddress ? null : wrappedOwner;
+    }
+
+    return registryOwner;
   } catch {
     return null;
   }

--- a/packages/resolver/src/utils/ens.ts
+++ b/packages/resolver/src/utils/ens.ts
@@ -13,7 +13,7 @@ import {
   type Address,
   type PublicClient,
 } from "viem";
-import { normalize } from "viem/ens";
+import { labelhash, normalize } from "viem/ens";
 import { mainnet } from "viem/chains";
 
 const DEFAULT_RPC = "https://eth.drpc.org";
@@ -26,6 +26,11 @@ const ENS_REGISTRY_ADDRESS: Address =
 // the resolver is mainnet-only today, so we only check the mainnet address here.
 const NAME_WRAPPER_ADDRESS: Address =
   "0xD4416b13d2b3a9aBae7AcD5D6C2BbDBE25686401";
+
+// Mainnet BaseRegistrar (.eth). Owns all unwrapped .eth 2LDs at the registry
+// level; the actual controller is BaseRegistrar.ownerOf(uint256(labelhash)).
+const BASE_REGISTRAR_ADDRESS: Address =
+  "0x57f1887a8BF19b14fC0dF6Fd9B2acc9Af147eA85";
 
 const REGISTRY_ABI = [
   {
@@ -43,6 +48,16 @@ const NAME_WRAPPER_ABI = [
     name: "ownerOf",
     stateMutability: "view",
     inputs: [{ name: "id", type: "uint256" }],
+    outputs: [{ name: "", type: "address" }],
+  },
+] as const;
+
+const BASE_REGISTRAR_ABI = [
+  {
+    type: "function",
+    name: "ownerOf",
+    stateMutability: "view",
+    inputs: [{ name: "tokenId", type: "uint256" }],
     outputs: [{ name: "", type: "address" }],
   },
 ] as const;
@@ -146,8 +161,14 @@ export async function resolveAddress(
  * Get the registry owner of an ENS name — the address that controls the
  * name and is authorized to sign records on its behalf.
  *
- * Reads `Registry.owner(node)`. If the registry owner is the NameWrapper,
- * unwraps via `NameWrapper.ownerOf(uint256(node))` to return the true owner.
+ * Resolution chain:
+ * 1. `Registry.owner(node)` → registry owner.
+ * 2. If owner is the NameWrapper, unwrap via `NameWrapper.ownerOf(uint256(node))`.
+ * 3. If owner is the BaseRegistrar (unwrapped `.eth` 2LDs), look up the true
+ *    controller via `BaseRegistrar.ownerOf(uint256(labelhash(label)))` —
+ *    the registry owner for these names is the registrar contract itself,
+ *    not the user.
+ * 4. Otherwise, return the registry owner.
  *
  * This is the right address for verifying record signatures (AIP manifests,
  * ENSIP-25 links, etc.) — distinct from `addr()`, which is the payment
@@ -160,7 +181,8 @@ export async function getOwner(
   name: string,
 ): Promise<Address | null> {
   try {
-    const node = namehash(normalizeName(name));
+    const normalized = normalizeName(name);
+    const node = namehash(normalized);
     const registryOwner = (await client.readContract({
       address: ENS_REGISTRY_ADDRESS,
       abi: REGISTRY_ABI,
@@ -178,6 +200,23 @@ export async function getOwner(
         args: [BigInt(node)],
       })) as Address;
       return wrappedOwner === zeroAddress ? null : wrappedOwner;
+    }
+
+    if (registryOwner.toLowerCase() === BASE_REGISTRAR_ADDRESS.toLowerCase()) {
+      // BaseRegistrar issues NFT-style ownership of `.eth` 2LDs; the tokenId
+      // is the labelhash of the leftmost label (e.g. "alice" for "alice.eth").
+      // Only valid for two-label `.eth` names — guard against mis-routing
+      // deeper subnames whose registry owner happens to be the registrar.
+      const labels = normalized.split(".");
+      if (labels.length !== 2 || labels[1] !== "eth") return null;
+
+      const baseOwner = (await client.readContract({
+        address: BASE_REGISTRAR_ADDRESS,
+        abi: BASE_REGISTRAR_ABI,
+        functionName: "ownerOf",
+        args: [BigInt(labelhash(labels[0]))],
+      })) as Address;
+      return baseOwner === zeroAddress ? null : baseOwner;
     }
 
     return registryOwner;


### PR DESCRIPTION
## Summary
- `verifyManifestSignature` now calls `getOwner(client, ensName)` instead of `resolveAddress(client, ensName)` — fixes manifest verification for any ENS name whose `addr()` is a smart contract (ERC-4337 kernels, Safes, etc.).
- Rewrote `getOwner` to actually read `Registry.owner(node)` and unwrap `NameWrapper.ownerOf(uint256(node))` when the registry owner is the wrapper. Previously it was just delegating to `resolveAddress`, which was the source of the bug.

## Why
For names like `daemon.trustrust.eth` (registry owner = EOA, `addr()` = ZeroDev kernel), the owner EOA correctly signed the manifest but the resolver was verifying against the kernel address. `verifyMessage`'s ERC-1271 fallback also missed because `ensemble manifest create` emits raw EOA sigs, not validator-shaped sigs the kernel would accept.

The fix restores the intended AIP V2 semantic: *"whoever controls this ENS name authored this profile."* Authority lives on the registry, not on `addr()`. `addr()` stays free for its actual job (payment routing). Names owned by smart-contract wallets naturally land in `verifyMessage`'s ERC-1271 path on the registry side.

## What stays the same
- `addr()` resolution is untouched everywhere else (`resolve.ts`, `skill.ts`).
- No new dependencies; uses `viem`'s `namehash` + `readContract` against the canonical mainnet ENS Registry / NameWrapper addresses already documented in `packages/cli/config/deployments.ts`.
- Sepolia uses the same Registry but a different NameWrapper — noted in a comment; the resolver is mainnet-only today (`createEnsClient` hardcodes `mainnet`).

Closes #41

## Test plan
- [x] `pnpm typecheck` — clean
- [x] `pnpm --filter @synthesis/resolver test` — 17/17 pass
- [x] `pnpm build:resolver` — clean
- [ ] Re-resolve `daemon.trustrust.eth` end-to-end and confirm `signatureValid: true`

🤖 Generated with [Claude Code](https://claude.com/claude-code)