### PR TITLE
feat(cli,resolver): ensemble agent verify <ens-name> (closes #45)

### DIFF
--- a/packages/cli/commands/agent-verify.test.ts
+++ b/packages/cli/commands/agent-verify.test.ts
@@ -1,0 +1,135 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { AgentVerifyErrorCode, type AgentVerifyResult } from "@synthesis/resolver";
+import { exitCodeFor, formatResult } from "./agent-verify";
+
+function strip(s: string): string {
+  // remove ANSI escape sequences so tests don't depend on the colors lib
+  // eslint-disable-next-line no-control-regex
+  return s.replace(/\x1b\[[0-9;]*m/g, "");
+}
+
+const baseResult: AgentVerifyResult = {
+  ensName: "emilemarcelagustin.eth",
+  verified: true,
+  identityCard: {
+    ensName: "emilemarcelagustin.eth",
+    agentId: "24994",
+    registryChain: "eip155:8453",
+    registryAddress: "0x8004A169FB4a3325136EB29fA0ceB6D2e539a432",
+    ownerAddress: "0xeb0ABB367540f90B57b3d5719fd2b9c740a15022",
+    kernelWallet: "0xEc0d3C782C6087235Ab16d8c4d4188d10DFD796A",
+    runtimePubkey: "0x8973B6897554017d208DBeE2Ef5Fb8Fb046A6aEB",
+    endpointWeb: "https://xxje1rfb.agents.pinata.cloud/app",
+  },
+  layers: {
+    records: { passed: true, missing: [], malformed: [] },
+    schema: { passed: true, schemaUri: "ipfs://x/schemas/agent-schema-v1.json", errors: [] },
+    integrity: {
+      passed: true,
+      expected: "0x6f3878cb630f8d16e5f8eac858f8923d15d5475773c1205b97dab0b06b35c114",
+      computed: "0x6f3878cb630f8d16e5f8eac858f8923d15d5475773c1205b97dab0b06b35c114",
+      policyGateway: "https://w3s.link/ipfs/",
+    },
+    binding: { passed: true, details: ["everything matches"] },
+    liveness: { passed: true, responseStatus: 200 },
+    signature: { passed: null, skipped: true },
+  },
+  policy: {
+    uri: "ipfs://x/policies/delegation-policy-v1.json",
+    version: "v1",
+    scope: ["eip191-sign", "eip712-sign"],
+    permittedClasses: ["identity-attestation"],
+    prohibited: ["userop-broadcast"],
+  },
+  warnings: [],
+  errors: [],
+};
+
+test("formatResult json — emits the locked AgentVerifyResult shape", () => {
+  const out = formatResult(baseResult, "json", false);
+  const parsed = JSON.parse(out);
+  // top-level keys
+  assert.deepEqual(
+    Object.keys(parsed).sort(),
+    ["ensName", "errors", "identityCard", "layers", "policy", "verified", "warnings"],
+  );
+  // layers keys
+  assert.deepEqual(
+    Object.keys(parsed.layers).sort(),
+    ["binding", "integrity", "liveness", "records", "schema", "signature"],
+  );
+  // identity card keys (shape locked for the explorer route to type against)
+  assert.deepEqual(
+    Object.keys(parsed.identityCard).sort(),
+    [
+      "agentId",
+      "endpointWeb",
+      "ensName",
+      "kernelWallet",
+      "ownerAddress",
+      "registryAddress",
+      "registryChain",
+      "runtimePubkey",
+    ],
+  );
+});
+
+test("formatResult human — pass case shows VERIFIED + 5 layer ✓ rows", () => {
+  const out = strip(formatResult(baseResult, "human", false));
+  assert.match(out, /Identity Card/);
+  assert.match(out, /VERIFIED/);
+  assert.match(out, /✓ Records/);
+  assert.match(out, /✓ Schema/);
+  assert.match(out, /✓ Integrity/);
+  assert.match(out, /✓ Binding/);
+  assert.match(out, /✓ Liveness/);
+  // signature skipped row uses a "-" not a "✓" or "✗"
+  assert.match(out, /- Signature\s*: skipped/);
+});
+
+test("formatResult human — failed records shows missing + malformed", () => {
+  const failed: AgentVerifyResult = {
+    ...baseResult,
+    verified: false,
+    layers: {
+      ...baseResult.layers,
+      records: {
+        passed: false,
+        missing: ["policy-hash"],
+        malformed: [{ key: "runtime-pubkey", reason: "not a 0x-address" }],
+        errorCode: AgentVerifyErrorCode.RECORDS_MISSING,
+      },
+    },
+  };
+  const out = strip(formatResult(failed, "human", false));
+  assert.match(out, /✗ Records/);
+  assert.match(out, /missing: policy-hash/);
+  assert.match(out, /malformed: runtime-pubkey/);
+  assert.match(out, /FAILED/);
+});
+
+test("exitCodeFor — 0 on verified, 1 on failure", () => {
+  assert.equal(exitCodeFor(baseResult), 0);
+  const failed = { ...baseResult, verified: false };
+  assert.equal(exitCodeFor(failed), 1);
+});
+
+test("formatResult json — failure carries error codes verbatim", () => {
+  const failed: AgentVerifyResult = {
+    ...baseResult,
+    verified: false,
+    layers: {
+      ...baseResult.layers,
+      integrity: {
+        passed: false,
+        expected: "0xaaaa",
+        computed: "0xbbbb",
+        policyGateway: "https://w3s.link/ipfs/",
+        errorCode: AgentVerifyErrorCode.INTEGRITY_HASH_MISMATCH,
+      },
+    },
+  };
+  const parsed = JSON.parse(formatResult(failed, "json", false));
+  assert.equal(parsed.layers.integrity.errorCode, "INTEGRITY_HASH_MISMATCH");
+});

--- a/packages/cli/commands/agent-verify.test.ts
+++ b/packages/cli/commands/agent-verify.test.ts
@@ -1,7 +1,7 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
 import { AgentVerifyErrorCode, type AgentVerifyResult } from "@synthesis/resolver";
-import { exitCodeFor, formatResult } from "./agent-verify";
+import { exitCodeFor, formatResult, agentVerify } from "./agent-verify";
 
 function strip(s: string): string {
   // remove ANSI escape sequences so tests don't depend on the colors lib
@@ -113,6 +113,28 @@ test("exitCodeFor — 0 on verified, 1 on failure", () => {
   assert.equal(exitCodeFor(baseResult), 0);
   const failed = { ...baseResult, verified: false };
   assert.equal(exitCodeFor(failed), 1);
+});
+
+test("agentVerify rejects non-numeric --timeout with exit code 2", async () => {
+  const prevExit = process.exitCode;
+  process.exitCode = 0;
+  await assert.rejects(
+    () => agentVerify({ name: "vitalik.eth", timeout: "foo" }),
+    /Invalid --timeout/,
+  );
+  assert.equal(process.exitCode, 2);
+  process.exitCode = prevExit;
+});
+
+test("agentVerify rejects negative --timeout with exit code 2", async () => {
+  const prevExit = process.exitCode;
+  process.exitCode = 0;
+  await assert.rejects(
+    () => agentVerify({ name: "vitalik.eth", timeout: "-5" }),
+    /Invalid --timeout/,
+  );
+  assert.equal(process.exitCode, 2);
+  process.exitCode = prevExit;
 });
 
 test("formatResult json — failure carries error codes verbatim", () => {

--- a/packages/cli/commands/agent-verify.ts
+++ b/packages/cli/commands/agent-verify.ts
@@ -48,10 +48,27 @@ export async function agentVerify(options: AgentVerifyCliOptions): Promise<Agent
       (arg === "-f" && arr[i + 1] === "json"),
   );
   const isJson = options.format === "json" || argvSaysJson;
+  // Defense-in-depth: the incur schema regexes timeout to digits, but be
+  // explicit so a future schema change can't silently produce NaN here.
+  let timeoutMs: number | undefined;
+  if (options.timeout !== undefined) {
+    const parsed = Number(options.timeout);
+    if (!Number.isFinite(parsed) || parsed <= 0) {
+      const message = `Invalid --timeout: "${options.timeout}" (expected a positive integer in ms)`;
+      if (isJson) {
+        console.log(JSON.stringify({ error: message }, null, 2));
+      } else {
+        console.error(colors.red(message));
+      }
+      process.exitCode = 2;
+      throw new Error(message);
+    }
+    timeoutMs = parsed;
+  }
   const verifyOptions: AgentVerifyOptions = {
     ensRpcUrl: options.rpc,
     ipfsGateways: options.ipfsGateway,
-    timeoutMs: options.timeout ? Number(options.timeout) : undefined,
+    timeoutMs,
     probeSign: options.probeSign,
   };
 

--- a/packages/cli/commands/agent-verify.ts
+++ b/packages/cli/commands/agent-verify.ts
@@ -1,0 +1,246 @@
+/**
+ * `ensemble agent verify <ens-name>` — CLI presenter.
+ *
+ * Pure presentation: parse flags, call verifyAgentIdentity, format. The
+ * structured AgentVerifyResult is emitted directly when --format json is
+ * passed (the synthesis explorer route consumes that shape verbatim).
+ */
+
+import colors from "yoctocolors";
+import {
+  verifyAgentIdentity,
+  type AgentVerifyResult,
+  type AgentVerifyOptions,
+} from "@synthesis/resolver";
+import { startSpinner, stopSpinner } from "../utils/spinner";
+
+export interface AgentVerifyCliOptions {
+  name: string;
+  probeSign?: boolean;
+  ipfsGateway?: string[];
+  rpc?: string;
+  timeout?: string;
+  format?: string;
+  explain?: boolean;
+}
+
+/**
+ * Run agent identity verification and print results.
+ *
+ * Returns the structured result so callers (incur returns it as the command
+ * value) can introspect, but printing happens here. Exit-code policy is
+ * handled by the top-level `process.exitCode` assignment in this function:
+ *   0 — verified
+ *   1 — any layer failed
+ *   2 — invalid input (caller-side; not used here, reserved for incur input
+ *       validation, which already exits 2 on Zod parse errors)
+ */
+export async function agentVerify(options: AgentVerifyCliOptions): Promise<AgentVerifyResult> {
+  // The incur framework owns the global `--format json` flag — when present
+  // it auto-renders the run() return value as JSON on stdout. Our command's
+  // own `format` option may not be populated when the global flag fires, so
+  // also peek at argv to keep the human-readable output suppressed in either
+  // case. Otherwise users see both the colored human display AND the JSON.
+  const argvSaysJson = process.argv.some(
+    (arg, i, arr) =>
+      arg === "--format=json" ||
+      (arg === "--format" && arr[i + 1] === "json") ||
+      (arg === "-f" && arr[i + 1] === "json"),
+  );
+  const isJson = options.format === "json" || argvSaysJson;
+  const verifyOptions: AgentVerifyOptions = {
+    ensRpcUrl: options.rpc,
+    ipfsGateways: options.ipfsGateway,
+    timeoutMs: options.timeout ? Number(options.timeout) : undefined,
+    probeSign: options.probeSign,
+  };
+
+  if (!isJson) {
+    startSpinner(`Verifying agent identity for ${colors.cyan(options.name)}...`);
+  }
+
+  let result: AgentVerifyResult;
+  try {
+    result = await verifyAgentIdentity(options.name, verifyOptions);
+  } catch (err) {
+    stopSpinner();
+    const message = (err as Error).message;
+    if (isJson) {
+      const failureShape: AgentVerifyResult = {
+        ensName: options.name,
+        verified: false,
+        identityCard: {
+          ensName: options.name,
+          agentId: null,
+          registryChain: null,
+          registryAddress: null,
+          ownerAddress: null,
+          kernelWallet: null,
+          runtimePubkey: null,
+          endpointWeb: null,
+        },
+        layers: {
+          records: { passed: false, missing: [], malformed: [] },
+          schema: { passed: false, schemaUri: null, errors: [] },
+          integrity: { passed: false, expected: null, computed: null, policyGateway: null },
+          binding: { passed: false, details: [] },
+          liveness: { passed: false, responseStatus: null },
+          signature: { passed: null, skipped: true },
+        },
+        policy: {
+          uri: null,
+          version: null,
+          scope: null,
+          permittedClasses: null,
+          prohibited: null,
+        },
+        warnings: [],
+        errors: [message],
+      };
+      console.log(JSON.stringify(failureShape, null, 2));
+    } else {
+      console.error(colors.red(`Error verifying ${options.name}: ${message}`));
+    }
+    process.exitCode = 1;
+    throw err;
+  }
+
+  stopSpinner();
+
+  console.log(formatResult(result, isJson ? "json" : "human", options.explain ?? false));
+
+  process.exitCode = exitCodeFor(result);
+  return result;
+}
+
+/** 0 on full pass, 1 on any layer failure. (Exit code 2 is reserved for input
+ * errors and is set by the incur framework on Zod parse failures.) */
+export function exitCodeFor(result: AgentVerifyResult): 0 | 1 {
+  return result.verified ? 0 : 1;
+}
+
+/** Render the verify result as a string. Pure — no side effects. Used by
+ * the CLI command and by `agent-verify.test.ts` to assert output shape. */
+export function formatResult(
+  result: AgentVerifyResult,
+  format: "json" | "human",
+  explain: boolean,
+): string {
+  if (format === "json") return JSON.stringify(result, null, 2);
+  return renderHuman(result, explain);
+}
+
+function renderHuman(result: AgentVerifyResult, explain: boolean): string {
+  const lines: string[] = [];
+  const card = result.identityCard;
+  lines.push("");
+  lines.push(colors.bold("  Identity Card"));
+  lines.push(colors.dim("  ─────────────"));
+  lines.push(`    ENS name        : ${colors.cyan(result.ensName)}`);
+  lines.push(`    Owner           : ${colors.dim(card.ownerAddress ?? "unresolved")}`);
+  lines.push(`    Kernel wallet   : ${colors.dim(card.kernelWallet ?? "unresolved")}`);
+  lines.push(`    Runtime pubkey  : ${colors.dim(card.runtimePubkey ?? "unresolved")}`);
+  lines.push(`    Endpoint        : ${colors.dim(card.endpointWeb ?? "unresolved")}`);
+  lines.push("");
+  lines.push(colors.bold("  Layered Verification"));
+  lines.push(colors.dim("  ────────────────────"));
+
+  const r = result.layers;
+  lines.push(layerLine(
+    "Records",
+    r.records.passed,
+    r.records.passed
+      ? "9/9 ENSIP-64 keys present and well-typed"
+      : [
+          r.records.missing.length > 0 && `missing: ${r.records.missing.join(", ")}`,
+          r.records.malformed.length > 0 && `malformed: ${r.records.malformed.map((m) => m.key).join(", ")}`,
+        ].filter(Boolean).join("; "),
+  ));
+  if (explain && r.records.malformed.length > 0) {
+    for (const m of r.records.malformed) {
+      lines.push(colors.dim(`                   ${m.key}: ${m.reason}`));
+    }
+  }
+
+  lines.push(layerLine(
+    "Schema",
+    r.schema.passed,
+    r.schema.passed
+      ? `validated against ${r.schema.schemaUri}`
+      : `${r.schema.errors.length} validation error(s)`,
+  ));
+  if (explain && r.schema.errors.length > 0) {
+    for (const e of r.schema.errors.slice(0, 5)) {
+      lines.push(colors.dim(`                   ${e.path || "<root>"}: ${e.message}`));
+    }
+  }
+
+  lines.push(layerLine(
+    "Integrity",
+    r.integrity.passed,
+    r.integrity.passed
+      ? `keccak256(JCS(policy)) == ${r.integrity.expected?.slice(0, 10)}...`
+      : `expected ${r.integrity.expected?.slice(0, 10) ?? "?"}…, got ${r.integrity.computed?.slice(0, 10) ?? "?"}…`,
+  ));
+  if (explain && r.integrity.policyGateway) {
+    lines.push(colors.dim(`                   gateway: ${r.integrity.policyGateway}`));
+  }
+
+  lines.push(layerLine(
+    "Binding",
+    r.binding.passed,
+    r.binding.details[0] ?? (r.binding.passed ? "all bindings consistent" : "see --explain"),
+  ));
+  if (explain) {
+    for (const d of r.binding.details.slice(1)) {
+      lines.push(colors.dim(`                   ${d}`));
+    }
+  }
+
+  lines.push(layerLine(
+    "Liveness",
+    r.liveness.passed,
+    r.liveness.responseStatus
+      ? `GET /health → HTTP ${r.liveness.responseStatus}`
+      : "endpoint unreachable",
+  ));
+
+  if (r.signature.skipped) {
+    lines.push(`  ${colors.dim("-")} ${colors.dim("Signature")}    : skipped (use --probe-sign to challenge the daemon)`);
+  } else {
+    lines.push(layerLine(
+      "Signature",
+      r.signature.passed === true,
+      r.signature.passed
+        ? `recovered ${r.signature.recovered?.slice(0, 10)}… == runtime-pubkey`
+        : `recovered ${r.signature.recovered ?? "?"} != runtime-pubkey`,
+    ));
+    if (explain && r.signature.challenge) {
+      lines.push(colors.dim(`                   nonce: ${r.signature.challenge.nonce}`));
+      lines.push(colors.dim(`                   issuedAt: ${r.signature.challenge.issuedAt}`));
+    }
+  }
+
+  if (result.warnings.length > 0) {
+    lines.push("");
+    for (const w of result.warnings) lines.push(colors.yellow(`  ⚠ ${w}`));
+  }
+  if (result.errors.length > 0) {
+    lines.push("");
+    for (const e of result.errors) lines.push(colors.red(`  ✗ ${e}`));
+  }
+
+  lines.push("");
+  lines.push(result.verified
+    ? `  Result: ${colors.green("VERIFIED ✓")}`
+    : `  Result: ${colors.red("FAILED ✗")}`);
+  lines.push("");
+  return lines.join("\n");
+}
+
+function layerLine(name: string, passed: boolean, detail: string): string {
+  const icon = passed ? colors.green("✓") : colors.red("✗");
+  const label = passed ? colors.bold(name) : colors.dim(name);
+  const padded = (label + " ".repeat(Math.max(0, 14 - name.length))).slice(0, 50);
+  return `  ${icon} ${padded}: ${colors.dim(detail)}`;
+}

--- a/packages/cli/commands/index.ts
+++ b/packages/cli/commands/index.ts
@@ -16,6 +16,7 @@ export { nameContract } from "./name";
 export { renew } from "./renew";
 export { transfer } from "./transfer";
 export { registerAgent, linkAgent, agentInfo } from "./agent";
+export { agentVerify } from "./agent-verify";
 export { personhoodCheck, personhoodRegister } from "./personhood";
 export { trust } from "./trust";
 export { gate } from "./gate";

--- a/packages/cli/index.ts
+++ b/packages/cli/index.ts
@@ -815,6 +815,7 @@ agent.command("verify", {
 			.describe("Override the ENS-mainnet RPC URL (default: $ETH_RPC_URL or https://eth.drpc.org)"),
 		timeout: z
 			.string()
+			.regex(/^\d+$/, "must be a positive integer (ms)")
 			.optional()
 			.describe("Per-network-call timeout in ms (default: 10000)"),
 		format: z

--- a/packages/cli/index.ts
+++ b/packages/cli/index.ts
@@ -28,6 +28,7 @@ import {
 	registerAgent,
 	linkAgent,
 	agentInfo,
+	agentVerify,
 	personhoodCheck,
 	personhoodRegister,
 	trust as trustCmd,
@@ -784,6 +785,74 @@ agent.command("info", {
 	async run({ args, options }) {
 		await agentInfo({ agentId: args.agentId, chain: options.chain });
 		return { queried: args.agentId };
+	},
+});
+
+agent.command("verify", {
+	description:
+		"Verify an ENS-bound agent's identity through 5 layered checks (records, schema, integrity, binding, liveness). Add --probe-sign for a 6th signature challenge.",
+	args: z.object({
+		name: z
+			.string()
+			.describe("ENS name to verify (e.g., emilemarcelagustin.eth)"),
+	}),
+	options: z.object({
+		probeSign: z
+			.boolean()
+			.optional()
+			.describe(
+				"POST a unique challenge to <agent-endpoint[web]>/sign and assert recovered signer == runtime-pubkey",
+			),
+		ipfsGateway: z
+			.array(z.string())
+			.optional()
+			.describe(
+				"Override the IPFS gateway list (repeatable). First 200 wins. Default: w3s.link, gateway.pinata.cloud, cloudflare-ipfs.com, ipfs.io",
+			),
+		rpc: z
+			.string()
+			.optional()
+			.describe("Override the ENS-mainnet RPC URL (default: $ETH_RPC_URL or https://eth.drpc.org)"),
+		timeout: z
+			.string()
+			.optional()
+			.describe("Per-network-call timeout in ms (default: 10000)"),
+		format: z
+			.enum(["json"])
+			.optional()
+			.describe("Emit a structured AgentVerifyResult on stdout instead of the human layout"),
+		explain: z
+			.boolean()
+			.optional()
+			.describe("Print debug detail per layer (records, hash inputs, challenge nonce, signature value)"),
+	}),
+	alias: { probeSign: "p", format: "f" },
+	examples: [
+		{
+			args: { name: "emilemarcelagustin.eth" },
+			description: "Run all 5 verification layers",
+		},
+		{
+			args: { name: "emilemarcelagustin.eth" },
+			options: { probeSign: true },
+			description: "Add the 6th signature-challenge layer",
+		},
+		{
+			args: { name: "emilemarcelagustin.eth" },
+			options: { format: "json" },
+			description: "Machine-readable output for the explorer route",
+		},
+	],
+	async run({ args, options }) {
+		return await agentVerify({
+			name: args.name,
+			probeSign: options.probeSign,
+			ipfsGateway: options.ipfsGateway,
+			rpc: options.rpc,
+			timeout: options.timeout,
+			format: options.format,
+			explain: options.explain,
+		});
 	},
 });
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -15,6 +15,7 @@
     "typecheck": "tsc --noEmit",
     "dev": "tsx index.ts",
     "start": "node dist/index.js",
+    "test": "tsx --test commands/*.test.ts",
     "lint": "npx @biomejs/biome lint --write .",
     "format": "npx @biomejs/biome format --write ."
   },

--- a/packages/resolver/package.json
+++ b/packages/resolver/package.json
@@ -20,7 +20,7 @@
     "dev": "tsx src/index.ts",
     "lint": "npx @biomejs/biome lint --write .",
     "format": "npx @biomejs/biome format --write .",
-    "test": "tsx --test src/*.test.ts src/utils/*.test.ts src/wallets/*.test.ts"
+    "test": "tsx --test src/*.test.ts src/utils/*.test.ts src/layers/*.test.ts src/wallets/*.test.ts"
   },
   "dependencies": {
     "@namera-ai/sdk": "^0.1.0",

--- a/packages/resolver/src/index.ts
+++ b/packages/resolver/src/index.ts
@@ -52,6 +52,24 @@ export {
 } from "./layers/skill.js";
 
 export {
+  verifyAgentIdentity,
+  AGENT_RECORD_KEYS,
+  AgentVerifyErrorCode,
+  type AgentVerifyOptions,
+  type AgentVerifyResult,
+  type IdentityCard,
+  type LayerResultRecords,
+  type LayerResultSchema,
+  type LayerResultIntegrity,
+  type LayerResultBinding,
+  type LayerResultLiveness,
+  type LayerResultSignature,
+  type AgentRecordKey,
+} from "./layers/agent-verify.js";
+
+export { canonicalize, canonicalizeBytes } from "./utils/jcs.js";
+
+export {
   createEnsClient,
   normalizeName,
   getTextRecord,

--- a/packages/resolver/src/layers/agent-verify.test.ts
+++ b/packages/resolver/src/layers/agent-verify.test.ts
@@ -265,6 +265,67 @@ test("probe-sign mismatch — daemon signs with a different key ⇒ signature la
   assert.equal(result.verified, false);
 });
 
+test("https:// URIs flow through plain fetch, not the IPFS gateway race", async () => {
+  // A deployment using https:// for `schema` and `delegation` (allowed by
+  // the records-layer regex and the agent-schema spec) must be fetchable.
+  // testHooks.fetchIpfs is intentionally absent so https traffic goes
+  // through options.fetch.
+  const httpsRecords = {
+    ...recordsFixture.records,
+    schema: "https://emilemarcelagustin.eth.limo/schemas/agent-schema-v1.json",
+    delegation: "https://emilemarcelagustin.eth.limo/policies/delegation-policy-v1.json",
+  };
+  let httpsCalls = 0;
+  const fetchMock: typeof fetch = async (input: RequestInfo | URL) => {
+    const url = typeof input === "string" ? input : input.toString();
+    if (url.endsWith("/health")) return new Response("{}", { status: 200 });
+    if (url.includes("agent-schema-v1.json")) {
+      httpsCalls++;
+      return new Response(agentSchemaBytes, { status: 200 });
+    }
+    if (url.includes("delegation-policy-v1.json")) {
+      httpsCalls++;
+      return new Response(policyBytes, { status: 200 });
+    }
+    throw new Error(`unexpected fetch ${url}`);
+  };
+  const result = await verifyAgentIdentity("emilemarcelagustin.eth", {
+    fetch: fetchMock,
+    testHooks: {
+      readRecords: async () => httpsRecords,
+      // No fetchIpfs hook — https branch in fetchByScheme handles both
+      getOwner: async () => recordsFixture.ownerAddress as `0x${string}`,
+    },
+  });
+  assert.equal(httpsCalls, 2, "schema + policy should each be fetched once via https");
+  assert.equal(result.layers.records.passed, true);
+  assert.equal(result.layers.schema.passed, true);
+  assert.equal(result.layers.integrity.passed, true);
+});
+
+test("cbor: URI — rejected with explicit unsupported-scheme error", async () => {
+  const cborRecords = {
+    ...recordsFixture.records,
+    schema: "cbor:bafy/agent-schema-v1.cbor",
+  };
+  const result = await verifyAgentIdentity("emilemarcelagustin.eth", {
+    fetch: (async () => new Response("{}", { status: 200 })) as typeof fetch,
+    testHooks: {
+      readRecords: async () => cborRecords,
+      fetchIpfs: async () => {
+        throw new Error("should not be called for cbor:");
+      },
+      getOwner: async () => recordsFixture.ownerAddress as `0x${string}`,
+    },
+  });
+  assert.equal(result.layers.schema.passed, false);
+  assert.equal(
+    result.layers.schema.errorCode,
+    AgentVerifyErrorCode.SCHEMA_FETCH_FAILED,
+  );
+  assert.ok(result.errors.some((e) => /cbor:/.test(e)));
+});
+
 test("AGENT_RECORD_KEYS is the locked 9-key list", () => {
   assert.equal(AGENT_RECORD_KEYS.length, 9);
   assert.ok(AGENT_RECORD_KEYS.includes("policy-hash"));

--- a/packages/resolver/src/layers/agent-verify.test.ts
+++ b/packages/resolver/src/layers/agent-verify.test.ts
@@ -1,0 +1,272 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
+import {
+  privateKeyToAccount,
+  generatePrivateKey,
+} from "viem/accounts";
+import {
+  verifyAgentIdentity,
+  AGENT_RECORD_KEYS,
+  AgentVerifyErrorCode,
+  type AgentVerifyOptions,
+} from "./agent-verify.js";
+import { canonicalizeBytes } from "../utils/jcs.js";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const FIXTURE_DIR = resolve(__dirname, "../../test/fixtures/agent-verify");
+
+const recordsFixture = JSON.parse(
+  readFileSync(resolve(FIXTURE_DIR, "records.json"), "utf8"),
+) as { records: Record<string, string>; ownerAddress: string };
+
+const agentSchemaBytes = readFileSync(resolve(FIXTURE_DIR, "agent-schema-v1.json"));
+const policyBytes = readFileSync(resolve(FIXTURE_DIR, "delegation-policy-v1.json"));
+
+const SCHEMA_URI = recordsFixture.records.schema;
+const POLICY_URI = recordsFixture.records.delegation;
+
+function buildOptions(
+  overrides: {
+    records?: Record<string, string>;
+    policyOverride?: Uint8Array;
+    schemaOverride?: Uint8Array;
+    fetchOverride?: typeof fetch;
+    probeSign?: boolean;
+  } = {},
+): AgentVerifyOptions {
+  const records = overrides.records ?? recordsFixture.records;
+  return {
+    probeSign: overrides.probeSign,
+    fetch:
+      overrides.fetchOverride ??
+      (async () =>
+        new Response("{ \"agent\": \"emilemarcelagustin.eth\", \"ok\": true }", {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        })),
+    testHooks: {
+      readRecords: async () => records,
+      fetchIpfs: async (uri: string) => {
+        if (uri === SCHEMA_URI)
+          return { bytes: overrides.schemaOverride ?? new Uint8Array(agentSchemaBytes), gateway: "fixture" };
+        if (uri === POLICY_URI)
+          return { bytes: overrides.policyOverride ?? new Uint8Array(policyBytes), gateway: "fixture" };
+        throw new Error(`unexpected fetch: ${uri}`);
+      },
+      getOwner: async () => recordsFixture.ownerAddress as `0x${string}`,
+    },
+  };
+}
+
+test("happy path — all 5 layers pass against frozen fixtures", async () => {
+  const result = await verifyAgentIdentity("emilemarcelagustin.eth", buildOptions());
+  assert.equal(result.verified, true, JSON.stringify(result.errors));
+  assert.equal(result.layers.records.passed, true);
+  assert.equal(result.layers.schema.passed, true);
+  assert.equal(result.layers.integrity.passed, true);
+  assert.equal(result.layers.binding.passed, true);
+  assert.equal(result.layers.liveness.passed, true);
+  assert.equal(result.layers.signature.skipped, true);
+  assert.equal(
+    result.layers.integrity.computed,
+    "0x6f3878cb630f8d16e5f8eac858f8923d15d5475773c1205b97dab0b06b35c114",
+  );
+});
+
+test("missing record — `policy-hash` absent fails records layer with stable code", async () => {
+  const broken = { ...recordsFixture.records };
+  delete (broken as Record<string, string>)["policy-hash"];
+  const result = await verifyAgentIdentity(
+    "emilemarcelagustin.eth",
+    buildOptions({ records: broken }),
+  );
+  assert.equal(result.verified, false);
+  assert.equal(result.layers.records.passed, false);
+  assert.equal(result.layers.records.errorCode, AgentVerifyErrorCode.RECORDS_MISSING);
+  assert.deepEqual(result.layers.records.missing, ["policy-hash"]);
+  // Downstream layers should not have been evaluated
+  assert.equal(result.layers.schema.passed, false);
+  assert.equal(result.layers.integrity.passed, false);
+});
+
+test("malformed record — `policy-hash` not 0x-32-bytes fails with malformed code", async () => {
+  const broken = { ...recordsFixture.records, "policy-hash": "0xnothex" };
+  const result = await verifyAgentIdentity(
+    "emilemarcelagustin.eth",
+    buildOptions({ records: broken }),
+  );
+  assert.equal(result.layers.records.passed, false);
+  assert.equal(result.layers.records.errorCode, AgentVerifyErrorCode.RECORDS_MALFORMED);
+  assert.equal(result.layers.records.malformed[0]?.key, "policy-hash");
+});
+
+test("tampered policy — modifying a value changes computed hash and fails integrity", async () => {
+  // Tamper with a real value (issued-at) so the bytes change but the JSON is
+  // still parseable — exercises the integrity layer, not the parse-fail
+  // branch which is covered by POLICY_FETCH_FAILED.
+  const policy = JSON.parse(new TextDecoder().decode(policyBytes));
+  policy["issued-at"] = "1999-01-01T00:00:00Z";
+  const tampered = new TextEncoder().encode(JSON.stringify(policy));
+  const result = await verifyAgentIdentity(
+    "emilemarcelagustin.eth",
+    buildOptions({ policyOverride: tampered }),
+  );
+  assert.equal(result.layers.integrity.passed, false);
+  assert.equal(
+    result.layers.integrity.errorCode,
+    AgentVerifyErrorCode.INTEGRITY_HASH_MISMATCH,
+  );
+  assert.equal(
+    result.layers.integrity.expected,
+    "0x6f3878cb630f8d16e5f8eac858f8923d15d5475773c1205b97dab0b06b35c114",
+  );
+  assert.notEqual(result.layers.integrity.computed, result.layers.integrity.expected);
+});
+
+test("schema fail — runtime-pubkey not 0x-address fails schema layer", async () => {
+  const broken = { ...recordsFixture.records, "runtime-pubkey": "0xnotanaddress" };
+  // The records-layer regex check will fire first (it's strictly typed). To
+  // exercise the schema layer in isolation we keep records syntactically OK
+  // and instead inject a schema that demands a property not present.
+  const tighterSchema = JSON.stringify({
+    type: "object",
+    required: ["nonexistent-key"],
+    properties: { "nonexistent-key": { type: "string" } },
+  });
+  const result = await verifyAgentIdentity(
+    "emilemarcelagustin.eth",
+    buildOptions({
+      schemaOverride: new TextEncoder().encode(tighterSchema),
+    }),
+  );
+  // records layer still passes
+  assert.equal(result.layers.records.passed, true);
+  assert.equal(result.layers.schema.passed, false);
+  assert.equal(
+    result.layers.schema.errorCode,
+    AgentVerifyErrorCode.SCHEMA_VALIDATION_FAILED,
+  );
+  assert.ok(
+    result.layers.schema.errors.some((e) => /nonexistent-key/.test(e.message)),
+  );
+  // Confirm the records-malformed branch indeed catches `runtime-pubkey`
+  // when malformed (sanity for the assertion above):
+  const r2 = await verifyAgentIdentity(
+    "emilemarcelagustin.eth",
+    buildOptions({ records: broken }),
+  );
+  assert.equal(r2.layers.records.passed, false);
+});
+
+test("binding mismatch — session-key.address != runtime-pubkey", async () => {
+  const policy = JSON.parse(new TextDecoder().decode(policyBytes));
+  policy["active-session-key"].address = "0x" + "a".repeat(40);
+  const tampered = new TextEncoder().encode(JSON.stringify(policy));
+  // Re-sign integrity by also rewriting the policy-hash record so the
+  // integrity layer doesn't fail first and short-circuit binding.
+  const { keccak256, toHex } = await import("viem");
+  const newHash = keccak256(toHex(canonicalizeBytes(policy)));
+  const recordsForcedHash = { ...recordsFixture.records, "policy-hash": newHash };
+  const result = await verifyAgentIdentity(
+    "emilemarcelagustin.eth",
+    buildOptions({ policyOverride: tampered, records: recordsForcedHash }),
+  );
+  assert.equal(result.layers.integrity.passed, true);
+  assert.equal(result.layers.binding.passed, false);
+  assert.equal(
+    result.layers.binding.errorCode,
+    AgentVerifyErrorCode.BINDING_SESSION_KEY_MISMATCH,
+  );
+});
+
+test("probe-sign — recovered signer matches runtime-pubkey ⇒ pass", async () => {
+  // Build a synthetic runtime keypair and rewrite records to use its address,
+  // so we can deterministically produce a signature that must verify.
+  const pk = generatePrivateKey();
+  const account = privateKeyToAccount(pk);
+  const runtimePubkey = account.address;
+  const recordsWithKey: Record<string, string> = {
+    ...recordsFixture.records,
+    "runtime-pubkey": runtimePubkey,
+  };
+  // also patch the policy doc's active-session-key.address + policy-hash so
+  // earlier layers still pass.
+  const policy = JSON.parse(new TextDecoder().decode(policyBytes));
+  policy["active-session-key"].address = runtimePubkey;
+  const newPolicyBytes = new TextEncoder().encode(JSON.stringify(policy));
+  const { keccak256, toHex } = await import("viem");
+  const newHash = keccak256(toHex(canonicalizeBytes(policy)));
+  recordsWithKey["policy-hash"] = newHash;
+
+  const fetchMock: typeof fetch = async (input: RequestInfo | URL, init) => {
+    const url = typeof input === "string" ? input : input.toString();
+    if (url.endsWith("/health")) {
+      return new Response("{}", { status: 200 });
+    }
+    if (url.endsWith("/sign") && init?.method === "POST") {
+      // Verifier sends `{message: <jcs-canonical-string>}` per the locked
+      // protocol — daemon signs the literal string as EIP-191.
+      const body = JSON.parse(init.body as string) as { message: string };
+      const signature = await account.signMessage({ message: body.message });
+      return new Response(JSON.stringify({ signature }), { status: 200 });
+    }
+    throw new Error(`unexpected fetch ${url}`);
+  };
+
+  const result = await verifyAgentIdentity(
+    "emilemarcelagustin.eth",
+    buildOptions({
+      records: recordsWithKey,
+      policyOverride: newPolicyBytes,
+      fetchOverride: fetchMock,
+      probeSign: true,
+    }),
+  );
+
+  assert.equal(result.verified, true, JSON.stringify(result.errors));
+  assert.equal(result.layers.signature.passed, true);
+  assert.equal(result.layers.signature.skipped, false);
+  assert.equal(result.layers.signature.recovered?.toLowerCase(), runtimePubkey.toLowerCase());
+});
+
+test("probe-sign mismatch — daemon signs with a different key ⇒ signature layer fails", async () => {
+  // Daemon signs with key A but records pin runtime-pubkey to key B.
+  const recordsKeyB = { ...recordsFixture.records };
+  // generate key A (the daemon)
+  const pkA = generatePrivateKey();
+  const accountA = privateKeyToAccount(pkA);
+  const fetchMock: typeof fetch = async (input: RequestInfo | URL, init) => {
+    const url = typeof input === "string" ? input : input.toString();
+    if (url.endsWith("/health")) return new Response("{}", { status: 200 });
+    if (url.endsWith("/sign") && init?.method === "POST") {
+      const body = JSON.parse(init.body as string) as { message: string };
+      const signature = await accountA.signMessage({ message: body.message });
+      return new Response(JSON.stringify({ signature }), { status: 200 });
+    }
+    throw new Error(`unexpected fetch ${url}`);
+  };
+
+  const result = await verifyAgentIdentity(
+    "emilemarcelagustin.eth",
+    buildOptions({
+      records: recordsKeyB,
+      fetchOverride: fetchMock,
+      probeSign: true,
+    }),
+  );
+  assert.equal(result.layers.signature.passed, false);
+  assert.equal(
+    result.layers.signature.errorCode,
+    AgentVerifyErrorCode.SIGNATURE_RECOVER_MISMATCH,
+  );
+  assert.equal(result.verified, false);
+});
+
+test("AGENT_RECORD_KEYS is the locked 9-key list", () => {
+  assert.equal(AGENT_RECORD_KEYS.length, 9);
+  assert.ok(AGENT_RECORD_KEYS.includes("policy-hash"));
+  assert.ok(AGENT_RECORD_KEYS.includes("agent-endpoint[web]"));
+});

--- a/packages/resolver/src/layers/agent-verify.ts
+++ b/packages/resolver/src/layers/agent-verify.ts
@@ -16,6 +16,53 @@ import {
   getOwner,
 } from "../utils/ens.js";
 import { fetchIpfsRaw } from "../utils/ipfs.js";
+
+interface FetchedDocument {
+  bytes: Uint8Array;
+  gateway: string;
+}
+
+/**
+ * Fetch a `schema` / `delegation` document by URI scheme. The records-layer
+ * regex accepts `ipfs://`, `https://`, and `cbor:` URIs to match the agent
+ * schema spec — so we must support fetching all three (or surface an explicit
+ * error). `cbor:` is reserved for a future binary-encoded variant and is not
+ * yet implemented; we reject it with a clear message rather than letting
+ * downstream JSON.parse fail.
+ */
+async function fetchByScheme(
+  uri: string,
+  options: { gateways?: string[]; timeoutMs: number; fetch: typeof fetch },
+  testHooks?: AgentVerifyOptions["testHooks"],
+): Promise<FetchedDocument> {
+  if (uri.startsWith("ipfs://")) {
+    if (testHooks?.fetchIpfs) return testHooks.fetchIpfs(uri);
+    return fetchIpfsRaw(uri, { gateways: options.gateways, timeoutMs: options.timeoutMs });
+  }
+  if (uri.startsWith("https://")) {
+    // https URIs go through the injected fetch directly — testHooks.fetchIpfs
+    // is intentionally only consulted for ipfs:// URIs so https schemes
+    // flow through real fetch logic during tests.
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), options.timeoutMs);
+    try {
+      const response = await options.fetch(uri, { signal: controller.signal });
+      if (!response.ok) {
+        throw new Error(`${uri} → HTTP ${response.status}`);
+      }
+      const buffer = await response.arrayBuffer();
+      return { bytes: new Uint8Array(buffer), gateway: new URL(uri).origin };
+    } finally {
+      clearTimeout(timer);
+    }
+  }
+  if (uri.startsWith("cbor:")) {
+    throw new Error(
+      `cbor: URI scheme not yet supported in agent verify v0.1 (only ipfs:// and https://). URI: ${uri}`,
+    );
+  }
+  throw new Error(`Unsupported URI scheme: ${uri}`);
+}
 import { canonicalizeBytes } from "../utils/jcs.js";
 import {
   validate as validateSchema,
@@ -82,7 +129,9 @@ export interface AgentVerifyOptions {
       ensName: string,
       keys: readonly string[],
     ) => Promise<Record<string, string>>;
-    fetchIpfs: (uri: string) => Promise<{ bytes: Uint8Array; gateway: string }>;
+    /** Only consulted for `ipfs://` URIs. `https://` URIs flow through
+     * `options.fetch`, and `cbor:` is rejected unconditionally. */
+    fetchIpfs?: (uri: string) => Promise<{ bytes: Uint8Array; gateway: string }>;
     getOwner?: (ensName: string) => Promise<Address | null>;
   };
 }
@@ -318,12 +367,11 @@ export async function verifyAgentIdentity(
 
   let agentSchema: Record<string, unknown> | null = null;
   try {
-    const fetched = options.testHooks
-      ? await options.testHooks.fetchIpfs(schemaUri)
-      : await fetchIpfsRaw(schemaUri, {
-          gateways: options.ipfsGateways,
-          timeoutMs,
-        });
+    const fetched = await fetchByScheme(
+      schemaUri,
+      { gateways: options.ipfsGateways, timeoutMs, fetch: fetchImpl },
+      options.testHooks,
+    );
     agentSchema = JSON.parse(new TextDecoder().decode(fetched.bytes));
   } catch (err) {
     result.layers.schema.passed = false;
@@ -349,12 +397,11 @@ export async function verifyAgentIdentity(
   // -------------------------------------------------------------------------
   let policyDoc: PolicyDoc | null = null;
   try {
-    const fetched = options.testHooks
-      ? await options.testHooks.fetchIpfs(records.delegation)
-      : await fetchIpfsRaw(records.delegation, {
-          gateways: options.ipfsGateways,
-          timeoutMs,
-        });
+    const fetched = await fetchByScheme(
+      records.delegation,
+      { gateways: options.ipfsGateways, timeoutMs, fetch: fetchImpl },
+      options.testHooks,
+    );
     policyDoc = JSON.parse(new TextDecoder().decode(fetched.bytes));
     result.layers.integrity.policyGateway = fetched.gateway;
   } catch (err) {

--- a/packages/resolver/src/layers/agent-verify.ts
+++ b/packages/resolver/src/layers/agent-verify.ts
@@ -1,0 +1,549 @@
+/**
+ * Agent identity verification — TRL extension for ENSIP-64 agent records.
+ *
+ * Reads 9 ENSIP-64 text records from an ENS name, fetches the agent + policy
+ * schemas + the policy doc itself from IPFS, then runs five layered checks
+ * (records, schema, integrity, binding, liveness) and an optional sixth
+ * (signature, via the operator's `/sign` HTTP endpoint).
+ *
+ * Read-only: never writes records or pins to IPFS.
+ */
+
+import { keccak256, toHex, recoverMessageAddress, type Address } from "viem";
+import {
+  createEnsClient,
+  getTextRecords,
+  getOwner,
+} from "../utils/ens.js";
+import { fetchIpfsRaw } from "../utils/ipfs.js";
+import { canonicalizeBytes } from "../utils/jcs.js";
+import {
+  validate as validateSchema,
+  type ValidationError,
+} from "../utils/agent-schema-validator.js";
+
+// =============================================================================
+// Public types
+// =============================================================================
+
+export const AGENT_RECORD_KEYS = [
+  "class",
+  "schema",
+  "runtime-pubkey",
+  "runtime-status",
+  "kernel-wallet",
+  "agent-endpoint[web]",
+  "delegation",
+  "policy-hash",
+  "policy-version",
+] as const;
+
+export type AgentRecordKey = (typeof AGENT_RECORD_KEYS)[number];
+
+/** Stable error codes per layer. Surfaced in `--format json` output for
+ * downstream consumers (the synthesis explorer route etc.) so they can
+ * render layer-specific UI without string-matching prose messages. */
+export enum AgentVerifyErrorCode {
+  // records
+  RECORDS_MISSING = "RECORDS_MISSING",
+  RECORDS_MALFORMED = "RECORDS_MALFORMED",
+  // schema
+  SCHEMA_FETCH_FAILED = "SCHEMA_FETCH_FAILED",
+  SCHEMA_VALIDATION_FAILED = "SCHEMA_VALIDATION_FAILED",
+  // integrity
+  POLICY_FETCH_FAILED = "POLICY_FETCH_FAILED",
+  INTEGRITY_HASH_MISMATCH = "INTEGRITY_HASH_MISMATCH",
+  // binding
+  BINDING_SESSION_KEY_MISMATCH = "BINDING_SESSION_KEY_MISMATCH",
+  BINDING_KERNEL_MISMATCH = "BINDING_KERNEL_MISMATCH",
+  BINDING_AGENT_MISMATCH = "BINDING_AGENT_MISMATCH",
+  // liveness
+  LIVENESS_HTTP_FAILED = "LIVENESS_HTTP_FAILED",
+  LIVENESS_BAD_RESPONSE = "LIVENESS_BAD_RESPONSE",
+  // signature (probe-sign)
+  SIGNATURE_PROBE_FAILED = "SIGNATURE_PROBE_FAILED",
+  SIGNATURE_RECOVER_MISMATCH = "SIGNATURE_RECOVER_MISMATCH",
+}
+
+export interface AgentVerifyOptions {
+  ensRpcUrl?: string;
+  ipfsGateways?: string[];
+  timeoutMs?: number;
+  probeSign?: boolean;
+  /** Inject a fetch impl for tests. Default: globalThis.fetch. */
+  fetch?: typeof fetch;
+  /**
+   * Inject record-resolution + IPFS fetch + owner lookup for tests. When
+   * provided, no network calls are made for ENS or IPFS. The HTTP probes
+   * (liveness, probe-sign) still go through `options.fetch`.
+   */
+  testHooks?: {
+    readRecords: (
+      ensName: string,
+      keys: readonly string[],
+    ) => Promise<Record<string, string>>;
+    fetchIpfs: (uri: string) => Promise<{ bytes: Uint8Array; gateway: string }>;
+    getOwner?: (ensName: string) => Promise<Address | null>;
+  };
+}
+
+export interface IdentityCard {
+  ensName: string;
+  agentId: string | null;
+  registryChain: string | null;
+  registryAddress: string | null;
+  ownerAddress: string | null;
+  kernelWallet: string | null;
+  runtimePubkey: string | null;
+  endpointWeb: string | null;
+}
+
+export interface LayerResultRecords {
+  passed: boolean;
+  missing: AgentRecordKey[];
+  malformed: { key: AgentRecordKey; reason: string }[];
+  errorCode?: AgentVerifyErrorCode;
+}
+export interface LayerResultSchema {
+  passed: boolean;
+  schemaUri: string | null;
+  errors: ValidationError[];
+  errorCode?: AgentVerifyErrorCode;
+}
+export interface LayerResultIntegrity {
+  passed: boolean;
+  expected: string | null;
+  computed: string | null;
+  policyGateway: string | null;
+  errorCode?: AgentVerifyErrorCode;
+}
+export interface LayerResultBinding {
+  passed: boolean;
+  details: string[];
+  errorCode?: AgentVerifyErrorCode;
+}
+export interface LayerResultLiveness {
+  passed: boolean;
+  responseStatus: number | null;
+  errorCode?: AgentVerifyErrorCode;
+}
+export interface LayerResultSignature {
+  passed: boolean | null;
+  skipped: boolean;
+  challenge?: { nonce: string; issuedAt: string; verifierId: string };
+  recovered?: string;
+  errorCode?: AgentVerifyErrorCode;
+}
+
+export interface AgentVerifyResult {
+  ensName: string;
+  verified: boolean;
+  identityCard: IdentityCard;
+  layers: {
+    records: LayerResultRecords;
+    schema: LayerResultSchema;
+    integrity: LayerResultIntegrity;
+    binding: LayerResultBinding;
+    liveness: LayerResultLiveness;
+    signature: LayerResultSignature;
+  };
+  policy: {
+    uri: string | null;
+    version: string | null;
+    scope: string[] | null;
+    permittedClasses: string[] | null;
+    prohibited: string[] | null;
+  };
+  warnings: string[];
+  errors: string[];
+}
+
+// =============================================================================
+// Helpers
+// =============================================================================
+
+const HEX_ADDR_RE = /^0x[0-9a-fA-F]{40}$/;
+const HEX_HASH_RE = /^0x[0-9a-fA-F]{64}$/;
+const URI_RE = /^(ipfs:\/\/|https:\/\/|cbor:).+/;
+
+function malformedReason(key: AgentRecordKey, value: string): string | null {
+  switch (key) {
+    case "class":
+      return value === "Agent" ? null : `expected "Agent"`;
+    case "schema":
+    case "delegation":
+      return URI_RE.test(value) ? null : `must start with ipfs://, https://, or cbor:`;
+    case "runtime-pubkey":
+    case "kernel-wallet":
+      return HEX_ADDR_RE.test(value) ? null : `not a 0x-prefixed 20-byte address`;
+    case "runtime-status":
+      return ["active", "paused", "revoked"].includes(value)
+        ? null
+        : `expected one of active|paused|revoked`;
+    case "agent-endpoint[web]":
+      return /^https?:\/\//.test(value) ? null : `not an http(s) URL`;
+    case "policy-hash":
+      return HEX_HASH_RE.test(value) ? null : `not a 0x-prefixed 32-byte hex string`;
+    case "policy-version":
+      return /^v[0-9]+(\.[0-9]+){0,2}$/.test(value) ? null : `expected v<N>[.<M>[.<P>]]`;
+    default:
+      return null;
+  }
+}
+
+interface PolicyDoc {
+  agent?: { "ens-name"?: string; "kernel-wallet"?: string };
+  version?: string;
+  "active-session-key"?: { address?: string; "kernel-wallet"?: string };
+  "delegation-policy"?: {
+    scope?: string[];
+    "permitted-message-classes"?: string[];
+    prohibited?: string[];
+  };
+}
+
+function emptyResult(ensName: string): AgentVerifyResult {
+  return {
+    ensName,
+    verified: false,
+    identityCard: {
+      ensName,
+      agentId: null,
+      registryChain: null,
+      registryAddress: null,
+      ownerAddress: null,
+      kernelWallet: null,
+      runtimePubkey: null,
+      endpointWeb: null,
+    },
+    layers: {
+      records: { passed: false, missing: [], malformed: [] },
+      schema: { passed: false, schemaUri: null, errors: [] },
+      integrity: { passed: false, expected: null, computed: null, policyGateway: null },
+      binding: { passed: false, details: [] },
+      liveness: { passed: false, responseStatus: null },
+      signature: { passed: null, skipped: true },
+    },
+    policy: {
+      uri: null,
+      version: null,
+      scope: null,
+      permittedClasses: null,
+      prohibited: null,
+    },
+    warnings: [],
+    errors: [],
+  };
+}
+
+function generateChallenge(): { nonce: string; issuedAt: string; verifierId: string } {
+  const bytes = new Uint8Array(16);
+  crypto.getRandomValues(bytes);
+  const nonce = "0x" + Array.from(bytes, (b) => b.toString(16).padStart(2, "0")).join("");
+  return {
+    nonce,
+    issuedAt: new Date().toISOString(),
+    verifierId: "ensemble-cli/agent-verify@v1",
+  };
+}
+
+// =============================================================================
+// Main
+// =============================================================================
+
+export async function verifyAgentIdentity(
+  ensName: string,
+  options: AgentVerifyOptions = {},
+): Promise<AgentVerifyResult> {
+  const result = emptyResult(ensName);
+  const fetchImpl = options.fetch ?? globalThis.fetch.bind(globalThis);
+  const timeoutMs = options.timeoutMs ?? 10_000;
+
+  // -------------------------------------------------------------------------
+  // Step 0: read records (off-chain via tests, otherwise live ENS)
+  // -------------------------------------------------------------------------
+  let records: Record<string, string>;
+  let owner: Address | null = null;
+  if (options.testHooks) {
+    records = await options.testHooks.readRecords(ensName, AGENT_RECORD_KEYS);
+    owner = options.testHooks.getOwner ? await options.testHooks.getOwner(ensName) : null;
+  } else {
+    const client = createEnsClient(options.ensRpcUrl);
+    records = await getTextRecords(client, ensName, AGENT_RECORD_KEYS as unknown as string[]);
+    owner = await getOwner(client, ensName);
+  }
+
+  // Identity Card from records (best-effort even if records layer fails)
+  result.identityCard.ownerAddress = owner ?? null;
+  result.identityCard.kernelWallet = records["kernel-wallet"] ?? null;
+  result.identityCard.runtimePubkey = records["runtime-pubkey"] ?? null;
+  result.identityCard.endpointWeb = records["agent-endpoint[web]"] ?? null;
+
+  // -------------------------------------------------------------------------
+  // Layer 1: records
+  // -------------------------------------------------------------------------
+  const missing: AgentRecordKey[] = [];
+  const malformed: { key: AgentRecordKey; reason: string }[] = [];
+  for (const key of AGENT_RECORD_KEYS) {
+    const v = records[key];
+    if (v === undefined || v === null || v === "") {
+      missing.push(key);
+      continue;
+    }
+    const reason = malformedReason(key, v);
+    if (reason) malformed.push({ key, reason });
+  }
+  result.layers.records.missing = missing;
+  result.layers.records.malformed = malformed;
+  result.layers.records.passed = missing.length === 0 && malformed.length === 0;
+  if (missing.length > 0) {
+    result.layers.records.errorCode = AgentVerifyErrorCode.RECORDS_MISSING;
+  } else if (malformed.length > 0) {
+    result.layers.records.errorCode = AgentVerifyErrorCode.RECORDS_MALFORMED;
+  }
+
+  if (!result.layers.records.passed) {
+    // Downstream layers cannot run meaningfully — return early with an
+    // explicit aggregated result.
+    return result;
+  }
+
+  // -------------------------------------------------------------------------
+  // Layer 2: schema (fetch agent schema, validate `records` against it)
+  // -------------------------------------------------------------------------
+  const schemaUri = records.schema;
+  result.layers.schema.schemaUri = schemaUri;
+  result.policy.uri = records.delegation;
+  result.policy.version = records["policy-version"];
+
+  let agentSchema: Record<string, unknown> | null = null;
+  try {
+    const fetched = options.testHooks
+      ? await options.testHooks.fetchIpfs(schemaUri)
+      : await fetchIpfsRaw(schemaUri, {
+          gateways: options.ipfsGateways,
+          timeoutMs,
+        });
+    agentSchema = JSON.parse(new TextDecoder().decode(fetched.bytes));
+  } catch (err) {
+    result.layers.schema.passed = false;
+    result.layers.schema.errorCode = AgentVerifyErrorCode.SCHEMA_FETCH_FAILED;
+    result.errors.push(`schema fetch failed: ${(err as Error).message}`);
+  }
+
+  if (agentSchema) {
+    // Validate the records-as-doc shape: build the implicit object the schema
+    // describes from the live ENS records, then validate.
+    const recordObj: Record<string, unknown> = {};
+    for (const key of AGENT_RECORD_KEYS) recordObj[key] = records[key];
+    const sv = validateSchema(recordObj, agentSchema);
+    result.layers.schema.passed = sv.valid;
+    result.layers.schema.errors = sv.errors;
+    if (!sv.valid) {
+      result.layers.schema.errorCode = AgentVerifyErrorCode.SCHEMA_VALIDATION_FAILED;
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  // Layer 3: integrity (keccak256(JCS(policy)) == policy-hash)
+  // -------------------------------------------------------------------------
+  let policyDoc: PolicyDoc | null = null;
+  try {
+    const fetched = options.testHooks
+      ? await options.testHooks.fetchIpfs(records.delegation)
+      : await fetchIpfsRaw(records.delegation, {
+          gateways: options.ipfsGateways,
+          timeoutMs,
+        });
+    policyDoc = JSON.parse(new TextDecoder().decode(fetched.bytes));
+    result.layers.integrity.policyGateway = fetched.gateway;
+  } catch (err) {
+    result.layers.integrity.passed = false;
+    result.layers.integrity.errorCode = AgentVerifyErrorCode.POLICY_FETCH_FAILED;
+    result.errors.push(`policy fetch failed: ${(err as Error).message}`);
+  }
+
+  if (policyDoc) {
+    const computed = keccak256(toHex(canonicalizeBytes(policyDoc as never)));
+    result.layers.integrity.expected = records["policy-hash"];
+    result.layers.integrity.computed = computed;
+    result.layers.integrity.passed = computed.toLowerCase() === records["policy-hash"].toLowerCase();
+    if (!result.layers.integrity.passed) {
+      result.layers.integrity.errorCode = AgentVerifyErrorCode.INTEGRITY_HASH_MISMATCH;
+    }
+
+    // Capture policy summary for output even if hash mismatches.
+    result.policy.scope = policyDoc["delegation-policy"]?.scope ?? null;
+    result.policy.permittedClasses =
+      policyDoc["delegation-policy"]?.["permitted-message-classes"] ?? null;
+    result.policy.prohibited = policyDoc["delegation-policy"]?.prohibited ?? null;
+  }
+
+  // -------------------------------------------------------------------------
+  // Layer 4: binding (policy.active-session-key == runtime-pubkey, etc.)
+  // -------------------------------------------------------------------------
+  if (policyDoc) {
+    const details: string[] = [];
+    let bindingPassed = true;
+    let bindingErrCode: AgentVerifyErrorCode | undefined;
+
+    const sessionAddr = policyDoc["active-session-key"]?.address;
+    if (sessionAddr && sessionAddr.toLowerCase() === records["runtime-pubkey"].toLowerCase()) {
+      details.push("active-session-key.address matches runtime-pubkey");
+    } else {
+      bindingPassed = false;
+      bindingErrCode ??= AgentVerifyErrorCode.BINDING_SESSION_KEY_MISMATCH;
+      details.push(
+        `active-session-key.address (${sessionAddr ?? "missing"}) != runtime-pubkey (${records["runtime-pubkey"]})`,
+      );
+    }
+
+    const sessionKernel = policyDoc["active-session-key"]?.["kernel-wallet"];
+    const agentKernel = policyDoc.agent?.["kernel-wallet"];
+    if (
+      sessionKernel?.toLowerCase() === records["kernel-wallet"].toLowerCase() &&
+      agentKernel?.toLowerCase() === records["kernel-wallet"].toLowerCase()
+    ) {
+      details.push("kernel-wallet matches across record + policy.agent + policy.active-session-key");
+    } else {
+      bindingPassed = false;
+      bindingErrCode ??= AgentVerifyErrorCode.BINDING_KERNEL_MISMATCH;
+      details.push(
+        `kernel-wallet mismatch: record=${records["kernel-wallet"]}, policy.agent=${agentKernel ?? "missing"}, policy.session=${sessionKernel ?? "missing"}`,
+      );
+    }
+
+    const policyEns = policyDoc.agent?.["ens-name"];
+    if (policyEns && policyEns.toLowerCase() === ensName.toLowerCase()) {
+      details.push(`policy.agent.ens-name matches ${ensName}`);
+    } else {
+      bindingPassed = false;
+      bindingErrCode ??= AgentVerifyErrorCode.BINDING_AGENT_MISMATCH;
+      details.push(`policy.agent.ens-name (${policyEns ?? "missing"}) != ${ensName}`);
+    }
+
+    result.layers.binding.passed = bindingPassed;
+    result.layers.binding.details = details;
+    if (!bindingPassed) result.layers.binding.errorCode = bindingErrCode;
+  } else {
+    result.layers.binding.passed = false;
+    result.layers.binding.details = ["skipped — no policy doc"];
+  }
+
+  // -------------------------------------------------------------------------
+  // Layer 5: liveness — GET <agent-endpoint[web]>/health
+  // -------------------------------------------------------------------------
+  const healthUrl = records["agent-endpoint[web]"].replace(/\/$/, "") + "/health";
+  try {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), timeoutMs);
+    let healthRes: Response;
+    try {
+      healthRes = await fetchImpl(healthUrl, { signal: controller.signal });
+    } finally {
+      clearTimeout(timer);
+    }
+    result.layers.liveness.responseStatus = healthRes.status;
+    if (!healthRes.ok) {
+      result.layers.liveness.passed = false;
+      result.layers.liveness.errorCode = AgentVerifyErrorCode.LIVENESS_HTTP_FAILED;
+    } else {
+      // Best-effort assertion: response should mention the ENS name OR include
+      // an `agent` field. We don't fail hard if neither is present — record a
+      // warning and pass on HTTP 200.
+      let bodyText = "";
+      try {
+        bodyText = await healthRes.text();
+      } catch {
+        bodyText = "";
+      }
+      result.layers.liveness.passed = true;
+      if (bodyText && !bodyText.includes(ensName)) {
+        result.warnings.push(
+          `liveness: /health response did not echo "${ensName}" — only HTTP 200 was asserted`,
+        );
+      }
+    }
+  } catch (err) {
+    result.layers.liveness.passed = false;
+    result.layers.liveness.errorCode = AgentVerifyErrorCode.LIVENESS_HTTP_FAILED;
+    result.errors.push(`liveness probe failed: ${(err as Error).message}`);
+  }
+
+  // -------------------------------------------------------------------------
+  // Layer 6 (optional): signature — POST a challenge to /sign, recover signer
+  // -------------------------------------------------------------------------
+  if (options.probeSign) {
+    const challenge = generateChallenge();
+    result.layers.signature.skipped = false;
+    result.layers.signature.challenge = challenge;
+    const signUrl = records["agent-endpoint[web]"].replace(/\/$/, "") + "/sign";
+    try {
+      // Sign protocol: the daemon's /sign endpoint accepts `{message: <string>}`
+      // and EIP-191 signs the literal string. Verifier sends the JCS-canonical
+      // envelope as the message string so the byte-exact value is reproducible
+      // on both sides. Daemon contract: see emilemarcelagustin.eth runtime.
+      const message = new TextDecoder().decode(canonicalizeBytes(challenge as never));
+      const controller = new AbortController();
+      const timer = setTimeout(() => controller.abort(), timeoutMs);
+      let signRes: Response;
+      try {
+        signRes = await fetchImpl(signUrl, {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ message }),
+          signal: controller.signal,
+        });
+      } finally {
+        clearTimeout(timer);
+      }
+      if (!signRes.ok) {
+        result.layers.signature.passed = false;
+        result.layers.signature.errorCode = AgentVerifyErrorCode.SIGNATURE_PROBE_FAILED;
+        result.errors.push(`probe-sign: HTTP ${signRes.status}`);
+      } else {
+        const body = (await signRes.json()) as { signature?: string };
+        const signature = body.signature;
+        if (!signature) {
+          result.layers.signature.passed = false;
+          result.layers.signature.errorCode = AgentVerifyErrorCode.SIGNATURE_PROBE_FAILED;
+          result.errors.push("probe-sign: response missing `signature` field");
+        } else {
+          const recovered = await recoverMessageAddress({
+            message,
+            signature: signature as `0x${string}`,
+          });
+          result.layers.signature.recovered = recovered;
+          if (recovered.toLowerCase() === records["runtime-pubkey"].toLowerCase()) {
+            result.layers.signature.passed = true;
+          } else {
+            result.layers.signature.passed = false;
+            result.layers.signature.errorCode = AgentVerifyErrorCode.SIGNATURE_RECOVER_MISMATCH;
+            result.errors.push(
+              `probe-sign: recovered signer (${recovered}) != runtime-pubkey (${records["runtime-pubkey"]})`,
+            );
+          }
+        }
+      }
+    } catch (err) {
+      result.layers.signature.passed = false;
+      result.layers.signature.errorCode = AgentVerifyErrorCode.SIGNATURE_PROBE_FAILED;
+      result.errors.push(`probe-sign: ${(err as Error).message}`);
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  // Aggregate
+  // -------------------------------------------------------------------------
+  const requiredLayers = [
+    result.layers.records.passed,
+    result.layers.schema.passed,
+    result.layers.integrity.passed,
+    result.layers.binding.passed,
+    result.layers.liveness.passed,
+  ];
+  const sigOK = options.probeSign ? result.layers.signature.passed === true : true;
+  result.verified = requiredLayers.every(Boolean) && sigOK;
+
+  return result;
+}

--- a/packages/resolver/src/utils/agent-schema-validator.ts
+++ b/packages/resolver/src/utils/agent-schema-validator.ts
@@ -1,0 +1,202 @@
+/**
+ * Hand-rolled JSON-Schema 2020-12 validator — minimum subset.
+ *
+ * Why hand-rolled vs Ajv: synthesis pulls no ajv (transitive or direct), and
+ * zod isn't a JSON-Schema validator (it can't ingest the JSON-Schema docs
+ * that the agent + delegation-policy schemas are authored in). The two
+ * schemas in `test/fixtures/agent-verify/` use only the keywords below, so a
+ * 100-line validator avoids a top-level dep without losing coverage.
+ *
+ * Supported keywords:
+ *   - type (string|number|integer|boolean|null|object|array)
+ *   - const, enum
+ *   - pattern (RegExp), format (date-time, uri)
+ *   - required, properties, additionalProperties
+ *   - items, minItems, maxItems
+ *   - minimum, maximum
+ *   - minLength, maxLength
+ *   - $schema, $id, title, description (informational, ignored for validation)
+ *
+ * Not supported (intentional): $ref, oneOf/anyOf/allOf/not, dependencies,
+ * patternProperties, contains, propertyNames. If a future schema needs
+ * these, swap to Ajv at that point.
+ */
+
+export interface ValidationError {
+  /** JSON-pointer-ish path to the offending value, e.g. `/delegators/0/role`. */
+  path: string;
+  /** Human-readable description of the violation. */
+  message: string;
+}
+
+export interface ValidationResult {
+  valid: boolean;
+  errors: ValidationError[];
+}
+
+type Schema = Record<string, unknown>;
+
+const ISO_DATE_TIME_RE =
+  /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:\d{2})$/;
+const URI_RE = /^[a-zA-Z][a-zA-Z0-9+.-]*:.+$/;
+
+export function validate(value: unknown, schema: Schema): ValidationResult {
+  const errors: ValidationError[] = [];
+  validateNode(value, schema, "", errors);
+  return { valid: errors.length === 0, errors };
+}
+
+function validateNode(
+  value: unknown,
+  schema: Schema,
+  path: string,
+  errors: ValidationError[],
+): void {
+  // type
+  if (schema.type !== undefined) {
+    const types = Array.isArray(schema.type) ? schema.type : [schema.type];
+    if (!types.some((t) => matchesType(value, t as string))) {
+      errors.push({
+        path,
+        message: `expected type ${types.join("|")}, got ${actualType(value)}`,
+      });
+      return; // downstream keywords assume the type matches
+    }
+  }
+
+  // const
+  if ("const" in schema) {
+    if (!deepEqual(value, schema.const)) {
+      errors.push({
+        path,
+        message: `expected const ${JSON.stringify(schema.const)}`,
+      });
+    }
+  }
+
+  // enum
+  if (Array.isArray(schema.enum)) {
+    if (!schema.enum.some((opt) => deepEqual(value, opt))) {
+      errors.push({
+        path,
+        message: `value not in enum [${schema.enum.map((x) => JSON.stringify(x)).join(", ")}]`,
+      });
+    }
+  }
+
+  if (typeof value === "string") {
+    if (typeof schema.pattern === "string") {
+      if (!new RegExp(schema.pattern).test(value)) {
+        errors.push({ path, message: `does not match pattern ${schema.pattern}` });
+      }
+    }
+    if (typeof schema.format === "string") {
+      if (schema.format === "date-time" && !ISO_DATE_TIME_RE.test(value)) {
+        errors.push({ path, message: `not a valid date-time` });
+      } else if (schema.format === "uri" && !URI_RE.test(value)) {
+        errors.push({ path, message: `not a valid uri` });
+      }
+    }
+    if (typeof schema.minLength === "number" && value.length < schema.minLength) {
+      errors.push({ path, message: `string shorter than minLength ${schema.minLength}` });
+    }
+    if (typeof schema.maxLength === "number" && value.length > schema.maxLength) {
+      errors.push({ path, message: `string longer than maxLength ${schema.maxLength}` });
+    }
+  }
+
+  if (typeof value === "number") {
+    if (typeof schema.minimum === "number" && value < schema.minimum) {
+      errors.push({ path, message: `value less than minimum ${schema.minimum}` });
+    }
+    if (typeof schema.maximum === "number" && value > schema.maximum) {
+      errors.push({ path, message: `value greater than maximum ${schema.maximum}` });
+    }
+  }
+
+  if (Array.isArray(value)) {
+    if (typeof schema.minItems === "number" && value.length < schema.minItems) {
+      errors.push({ path, message: `array shorter than minItems ${schema.minItems}` });
+    }
+    if (typeof schema.maxItems === "number" && value.length > schema.maxItems) {
+      errors.push({ path, message: `array longer than maxItems ${schema.maxItems}` });
+    }
+    if (schema.items && typeof schema.items === "object") {
+      for (let i = 0; i < value.length; i++) {
+        validateNode(value[i], schema.items as Schema, `${path}/${i}`, errors);
+      }
+    }
+  }
+
+  if (isPlainObject(value)) {
+    if (Array.isArray(schema.required)) {
+      for (const key of schema.required) {
+        if (!(key in value)) {
+          errors.push({ path, message: `missing required property "${key}"` });
+        }
+      }
+    }
+    const props = (schema.properties as Record<string, Schema> | undefined) ?? {};
+    for (const [k, v] of Object.entries(value)) {
+      if (k in props) {
+        validateNode(v, props[k], `${path}/${k}`, errors);
+      } else if (schema.additionalProperties === false) {
+        errors.push({ path: `${path}/${k}`, message: `additional property not allowed` });
+      } else if (
+        schema.additionalProperties &&
+        typeof schema.additionalProperties === "object"
+      ) {
+        validateNode(v, schema.additionalProperties as Schema, `${path}/${k}`, errors);
+      }
+    }
+  }
+}
+
+function matchesType(value: unknown, type: string): boolean {
+  switch (type) {
+    case "string":
+      return typeof value === "string";
+    case "number":
+      return typeof value === "number" && Number.isFinite(value);
+    case "integer":
+      return typeof value === "number" && Number.isInteger(value);
+    case "boolean":
+      return typeof value === "boolean";
+    case "null":
+      return value === null;
+    case "array":
+      return Array.isArray(value);
+    case "object":
+      return isPlainObject(value);
+    default:
+      return false;
+  }
+}
+
+function actualType(value: unknown): string {
+  if (value === null) return "null";
+  if (Array.isArray(value)) return "array";
+  if (Number.isInteger(value)) return "integer";
+  return typeof value;
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function deepEqual(a: unknown, b: unknown): boolean {
+  if (a === b) return true;
+  if (typeof a !== typeof b) return false;
+  if (a === null || b === null) return a === b;
+  if (Array.isArray(a) && Array.isArray(b)) {
+    if (a.length !== b.length) return false;
+    return a.every((v, i) => deepEqual(v, b[i]));
+  }
+  if (isPlainObject(a) && isPlainObject(b)) {
+    const ak = Object.keys(a);
+    const bk = Object.keys(b);
+    if (ak.length !== bk.length) return false;
+    return ak.every((k) => deepEqual(a[k], b[k]));
+  }
+  return false;
+}

--- a/packages/resolver/src/utils/ipfs.ts
+++ b/packages/resolver/src/utils/ipfs.ts
@@ -98,3 +98,77 @@ export function cidToUri(cid: string): string {
 export function cidToGatewayUrl(cid: string, gateway?: string): string {
   return `${gateway ?? PUBLIC_GATEWAYS[0]}${cid}`;
 }
+
+export interface FetchIpfsRawOptions {
+  /**
+   * Gateway base URLs (each must end with `/ipfs/` or include the trailing
+   * slash). First successful 200 wins. If omitted, defaults to PUBLIC_GATEWAYS.
+   */
+  gateways?: string[];
+  /** Per-request timeout in ms. Default: 10_000. */
+  timeoutMs?: number;
+}
+
+export interface FetchIpfsRawResult {
+  /** Winning gateway base URL. */
+  gateway: string;
+  /** Raw response body bytes — preserved exactly as served, for hashing. */
+  bytes: Uint8Array;
+}
+
+/**
+ * Race an IPFS URI across multiple gateways. First 200 wins; non-2xx and
+ * network errors are dropped. The whole race rejects only if every gateway
+ * fails or the overall timeout fires.
+ *
+ * Use this — not `fetchFromIpfs` — when the caller will hash the response
+ * bytes (e.g. policy-hash verification): we need to surface raw bytes, not
+ * a string that has been through `Response.text()` re-encoding.
+ */
+export async function fetchIpfsRaw(
+  uri: string,
+  options: FetchIpfsRawOptions = {},
+): Promise<FetchIpfsRawResult> {
+  // Parse `ipfs://<cid>[<path>]` directly. Note: extractCid() returns the
+  // entire CID-plus-path for multi-segment URIs, so don't reuse it here —
+  // we need cid and path as separate strings to avoid duplicating the path
+  // when we build the gateway URL.
+  const m = uri.match(/^ipfs:\/\/([^/]+)(\/.*)?$/);
+  if (!m) {
+    throw new Error(`Not an IPFS URI: ${uri}`);
+  }
+  const cid = m[1];
+  const path = m[2] ?? "";
+  const gateways = options.gateways?.length ? options.gateways : PUBLIC_GATEWAYS;
+  const timeoutMs = options.timeoutMs ?? 10_000;
+
+  const errors: string[] = [];
+  const attempts = gateways.map(async (gateway) => {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), timeoutMs);
+    try {
+      const url = `${gateway}${cid}${path}`;
+      const response = await fetch(url, { signal: controller.signal });
+      if (!response.ok) {
+        throw new Error(`${gateway} → HTTP ${response.status}`);
+      }
+      const buffer = await response.arrayBuffer();
+      return { gateway, bytes: new Uint8Array(buffer) };
+    } finally {
+      clearTimeout(timer);
+    }
+  });
+
+  // Promise.any — first fulfillment wins. Aggregates all rejections if none.
+  try {
+    return await Promise.any(attempts);
+  } catch (err) {
+    const aggregate = err as AggregateError;
+    for (const e of aggregate.errors ?? []) {
+      errors.push((e as Error).message ?? String(e));
+    }
+    throw new Error(
+      `All IPFS gateways failed for ${uri}: ${errors.join("; ")}`,
+    );
+  }
+}

--- a/packages/resolver/src/utils/jcs.test.ts
+++ b/packages/resolver/src/utils/jcs.test.ts
@@ -1,0 +1,74 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
+import { keccak256, toHex } from "viem";
+import { canonicalize, canonicalizeBytes } from "./jcs.js";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const FIXTURE_DIR = resolve(__dirname, "../../test/fixtures/agent-verify");
+
+test("canonicalize sorts object keys", () => {
+  assert.equal(canonicalize({ b: 1, a: 2 }), '{"a":2,"b":1}');
+  assert.equal(canonicalize({ z: { y: 1, x: 2 }, a: 3 }), '{"a":3,"z":{"x":2,"y":1}}');
+});
+
+test("canonicalize preserves array order", () => {
+  assert.equal(canonicalize([3, 1, 2]), "[3,1,2]");
+  assert.equal(canonicalize([{ b: 1, a: 2 }]), '[{"a":2,"b":1}]');
+});
+
+test("canonicalize emits no whitespace", () => {
+  const input = { hello: "world", n: 42, arr: [1, true, null] };
+  const out = canonicalize(input);
+  assert.ok(!/\s/.test(out), "output must contain no whitespace");
+});
+
+test("canonicalize handles primitives", () => {
+  assert.equal(canonicalize(null), "null");
+  assert.equal(canonicalize(true), "true");
+  assert.equal(canonicalize(false), "false");
+  assert.equal(canonicalize(0), "0");
+  assert.equal(canonicalize(-1.5), "-1.5");
+  assert.equal(canonicalize("hello"), '"hello"');
+});
+
+test("canonicalize escapes strings via JSON.stringify rules", () => {
+  assert.equal(canonicalize('a"b'), '"a\\"b"');
+  assert.equal(canonicalize("line\nbreak"), '"line\\nbreak"');
+});
+
+test("canonicalize rejects non-finite numbers", () => {
+  assert.throws(() => canonicalize(Number.NaN), /non-finite/);
+  assert.throws(() => canonicalize(Number.POSITIVE_INFINITY), /non-finite/);
+});
+
+test("canonicalize rejects -0", () => {
+  assert.throws(() => canonicalize(-0), /-0/);
+});
+
+test("canonicalize is whitespace-insensitive on input but byte-deterministic on output", () => {
+  const a = JSON.parse('{"b":1,  "a"  :  2}');
+  const b = JSON.parse('{ "a":2,"b":1 }');
+  assert.equal(canonicalize(a), canonicalize(b));
+});
+
+test("RFC 8785 §3.2.3 — keys sorted by UTF-16 code-unit order", () => {
+  // RFC 8785 Appendix B: keys with non-ASCII code points sort by code-unit
+  // order, which JS Array.prototype.sort over strings does by default.
+  assert.equal(canonicalize({ "é": 1, e: 2 }), '{"e":2,"é":1}');
+});
+
+test("frozen policy doc canonicalizes to the published keccak256 hash", () => {
+  const path = resolve(FIXTURE_DIR, "delegation-policy-v1.json");
+  const raw = readFileSync(path, "utf8");
+  const obj = JSON.parse(raw);
+  const bytes = canonicalizeBytes(obj);
+  const hash = keccak256(toHex(bytes));
+  assert.equal(
+    hash,
+    "0x6f3878cb630f8d16e5f8eac858f8923d15d5475773c1205b97dab0b06b35c114",
+    "JCS impl is incorrect — canonical-bytes hash diverges from the on-chain policy-hash record",
+  );
+});

--- a/packages/resolver/src/utils/jcs.ts
+++ b/packages/resolver/src/utils/jcs.ts
@@ -1,0 +1,64 @@
+/**
+ * RFC 8785 JSON Canonicalization Scheme (JCS) — minimal implementation.
+ *
+ * Two callers in the policy-verification path depend on byte-exact output:
+ *   keccak256(canonicalizeBytes(policyDoc)) === policy-hash on ENS
+ *
+ * This implementation handles the JSON subset our policy + schema docs use:
+ *   strings, numbers (integers + finite floats), booleans, null, arrays, objects.
+ *
+ * Behavior:
+ *   - Object keys sorted by UTF-16 code-unit order (the JS default for
+ *     `Array.prototype.sort` over strings) — matches RFC 8785 §3.2.3.
+ *   - No whitespace; identical to `JSON.stringify(value)` over a key-sorted tree.
+ *   - Throws on NaN, Infinity, -0 (the spec rejects them; our docs never
+ *     contain them, so this is defensive).
+ *
+ * NOT handled: bigint, custom toJSON, Date objects, undefined values
+ *   (callers should JSON.parse from text first; round-trip strips these).
+ */
+
+type JsonValue =
+  | string
+  | number
+  | boolean
+  | null
+  | JsonValue[]
+  | { [key: string]: JsonValue };
+
+function sortedClone(value: JsonValue): JsonValue {
+  if (value === null) return null;
+  if (typeof value === "number") {
+    if (!Number.isFinite(value)) {
+      throw new Error(`JCS: non-finite number not representable: ${value}`);
+    }
+    if (Object.is(value, -0)) {
+      throw new Error("JCS: -0 not representable");
+    }
+    return value;
+  }
+  if (typeof value === "string" || typeof value === "boolean") return value;
+  if (Array.isArray(value)) return value.map(sortedClone);
+  if (typeof value === "object") {
+    const out: { [key: string]: JsonValue } = {};
+    const keys = Object.keys(value).sort();
+    for (const k of keys) out[k] = sortedClone(value[k]);
+    return out;
+  }
+  throw new Error(`JCS: unsupported value type: ${typeof value}`);
+}
+
+/**
+ * Canonicalize a JSON-compatible value to its RFC 8785 string form.
+ */
+export function canonicalize(value: JsonValue): string {
+  return JSON.stringify(sortedClone(value));
+}
+
+/**
+ * Canonicalize a JSON-compatible value to its RFC 8785 UTF-8 bytes.
+ * This is the input to `keccak256` for `policy-hash` verification.
+ */
+export function canonicalizeBytes(value: JsonValue): Uint8Array {
+  return new TextEncoder().encode(canonicalize(value));
+}

--- a/packages/resolver/test/fixtures/agent-verify/README.md
+++ b/packages/resolver/test/fixtures/agent-verify/README.md
@@ -1,0 +1,14 @@
+# agent-verify fixtures
+
+Frozen offline copies of the live `emilemarcelagustin.eth` deployment, used by `agent-verify.test.ts` and `jcs.test.ts`. **Tests must not hit the network.**
+
+| File | Source | Frozen |
+|---|---|---|
+| `agent-schema-v1.json` | `bafybeighgfsdllcwlb7uvga5foqonx52vnoryede72jo6k2a4rtj5naq3i/schemas/agent-schema-v1.json` | 2026-05-05 |
+| `delegation-policy-schema-v1.json` | same dir CID, `/schemas/...` | 2026-05-05 |
+| `delegation-policy-v1.json` | `bafybeicqnxyjsvro7ipmdhhzymtk5y2qbaudzmtgggllt7midikdxkmoxi/policies/delegation-policy-v1.json` | 2026-05-05 |
+| `records.json` | canonical tuple in agency repo `deploy/ens-agent/.env.deploy` + `memory/ens-agent-emilemarcelagustin.md` | 2026-05-05 |
+
+`policy-hash` for the frozen `delegation-policy-v1.json` is `0x6f3878cb630f8d16e5f8eac858f8923d15d5475773c1205b97dab0b06b35c114` — the JCS canonicalizer test asserts this exactly. Mismatch ⇒ JCS implementation is wrong.
+
+To re-pin or refresh: bump the policy file in the agency repo (`deploy/ens-agent/`), re-pin via `make pin-policy` and `make pin-schema`, copy the four files back here, and update the table above.

--- a/packages/resolver/test/fixtures/agent-verify/agent-schema-v1.json
+++ b/packages/resolver/test/fixtures/agent-verify/agent-schema-v1.json
@@ -1,0 +1,50 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://emilemarcelagustin.eth.limo/schemas/agent-schema-v1.json",
+  "title": "ENS-bound agent identity (v1)",
+  "description": "JSON Schema 2020-12 doc referenced by the ENSIP-64 `schema` text record on emilemarcelagustin.eth. Defines the kebab-case text-record keys that describe the agent's runtime, kernel, and (later) policy/delegation surface. Property names match the ENS text-record keys on the same name. Versioning lives in $id; the keys themselves never carry version suffixes.",
+  "type": "object",
+  "additionalProperties": true,
+  "properties": {
+    "class": {
+      "type": "string",
+      "const": "Agent",
+      "description": "ENSIP-64 reserved global. Pascal-case classification of the named entity."
+    },
+    "schema": {
+      "type": "string",
+      "pattern": "^(ipfs://|cbor:|https://).+",
+      "description": "ENSIP-64 reserved global. URI of this schema document. MUST start with ipfs://, cbor:, or https://."
+    },
+    "runtime-pubkey": {
+      "type": "string",
+      "pattern": "^0x[0-9a-fA-F]{40}$",
+      "description": "EVM 0x address of the active session signer. Rotates when the session key rotates; rotation is reflected by updating this record (and bumping $id if semantics change)."
+    },
+    "runtime-status": {
+      "type": "string",
+      "enum": ["active", "paused", "revoked"],
+      "description": "Lifecycle of runtime-pubkey. `active` = currently signing; `paused` = signer valid but not authorized; `revoked` = signer rotated, this key no longer used (read for audit only)."
+    },
+    "kernel-wallet": {
+      "type": "string",
+      "pattern": "^0x[0-9a-fA-F]{40}$",
+      "description": "EVM 0x address of the Namera smart-account kernel that the session signer acts on behalf of. Stable across session-key rotations."
+    },
+    "policy-hash": {
+      "type": "string",
+      "pattern": "^0x[0-9a-fA-F]{64}$",
+      "description": "keccak256 hex of the canonical policy document bytes. Deterministic — same input bytes always produce the same hash. Bind a deployed runtime to a specific policy."
+    },
+    "policy-version": {
+      "type": "string",
+      "pattern": "^v[0-9]+(\\.[0-9]+){0,2}$",
+      "description": "Human-readable version of the policy document referenced by policy-hash. e.g. `v1`, `v1.2`."
+    },
+    "delegation": {
+      "type": "string",
+      "pattern": "^(ipfs://|https://).+",
+      "description": "URI of the delegation document binding the owner EOA to the kernel-wallet and authorizing the runtime-pubkey within the constraints of policy-hash. Pin to IPFS; mirror at HTTPS for readability."
+    }
+  }
+}

--- a/packages/resolver/test/fixtures/agent-verify/delegation-policy-schema-v1.json
+++ b/packages/resolver/test/fixtures/agent-verify/delegation-policy-schema-v1.json
@@ -1,0 +1,176 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://emilemarcelagustin.eth.limo/schemas/delegation-policy-schema-v1.json",
+  "title": "Agent delegation policy (v1)",
+  "description": "JSON Schema 2020-12 for the delegation policy document referenced by ENS text records `delegation` (URI) and `policy-hash` (keccak256 of canonical bytes) on emilemarcelagustin.eth. Declares the authorized delegators, scope of session-key authority, binding to the active session key, and revocation procedure. Versioning lives in $id; key names never carry version suffixes.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "$schema",
+    "$id",
+    "schema-uri",
+    "agent",
+    "version",
+    "issued-at",
+    "delegators",
+    "delegation-policy",
+    "active-session-key",
+    "revocation"
+  ],
+  "properties": {
+    "$schema": {
+      "type": "string",
+      "const": "https://json-schema.org/draft/2020-12/schema"
+    },
+    "$id": {
+      "type": "string",
+      "format": "uri",
+      "description": "Canonical HTTPS URL of this policy instance. MUST end in .../policies/delegation-policy-vN.json. Bump N on every policy change."
+    },
+    "schema-uri": {
+      "type": "string",
+      "pattern": "^(ipfs://|cbor:|https://).+",
+      "description": "URI of the schema document validating this instance. SHOULD be ipfs:// for content-addressed integrity."
+    },
+    "agent": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["ens-name", "agent-id", "kernel-wallet", "chain", "chain-id"],
+      "properties": {
+        "ens-name": { "type": "string", "pattern": "^[a-z0-9-]+\\.eth$" },
+        "agent-id": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "ERC-8004 Identity Registry token id on the chain identified by chain-id."
+        },
+        "kernel-wallet": {
+          "type": "string",
+          "pattern": "^0x[0-9a-fA-F]{40}$",
+          "description": "Smart-account kernel that the session key acts on behalf of. Stable across rotations."
+        },
+        "chain": { "type": "string", "enum": ["base-mainnet", "ethereum-mainnet"] },
+        "chain-id": { "type": "integer", "enum": [1, 8453] }
+      }
+    },
+    "version": {
+      "type": "string",
+      "pattern": "^v[0-9]+(\\.[0-9]+){0,2}$",
+      "description": "Human-readable version (v1, v1.1, v2). MUST match the suffix in $id."
+    },
+    "issued-at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "RFC 3339 timestamp when this policy version was authored."
+    },
+    "delegators": {
+      "type": "array",
+      "minItems": 1,
+      "maxItems": 8,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["label", "address", "role"],
+        "properties": {
+          "label": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 64,
+            "description": "Human-readable identifier (e.g. 'owner-eoa', 'estmcmxci.eth')."
+          },
+          "address": {
+            "type": "string",
+            "pattern": "^0x[0-9a-fA-F]{40}$"
+          },
+          "ens": {
+            "type": ["string", "null"],
+            "description": "ENS name that resolves to address, if any."
+          },
+          "role": {
+            "type": "string",
+            "enum": ["primary", "co-authority"],
+            "description": "primary = on-chain owner of the ENS name; co-authority = additional authorized signer per this policy."
+          }
+        }
+      }
+    },
+    "delegation-policy": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["threshold", "scope", "ttl-hours", "permitted-message-classes", "prohibited"],
+      "properties": {
+        "threshold": {
+          "type": "string",
+          "pattern": "^[0-9]+-of-[0-9]+$",
+          "description": "Signature threshold over the delegators array. e.g. '1-of-2'."
+        },
+        "scope": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "string",
+            "enum": ["eip191-sign", "eip712-sign"]
+          },
+          "description": "Cryptographic actions the active session key is authorized to perform."
+        },
+        "ttl-hours": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 8760,
+          "description": "Maximum lifetime (in hours) of any session key issued under this policy."
+        },
+        "permitted-message-classes": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "type": "string" },
+          "description": "Semantic classes of messages the session key may sign. Free-form strings; verifiers SHOULD reject signatures over messages outside these classes."
+        },
+        "prohibited": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Explicitly forbidden actions. Verifiers MUST reject any signed payload that performs these. Common entries: 'userop-broadcast', 'value-transfer', 'contract-write'."
+        }
+      }
+    },
+    "active-session-key": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["address", "issued-at", "ttl-hours", "kernel-wallet"],
+      "properties": {
+        "address": {
+          "type": "string",
+          "pattern": "^0x[0-9a-fA-F]{40}$",
+          "description": "Currently authorized session signer. MUST equal the runtime-pubkey ENS text record while this policy is in force."
+        },
+        "issued-at": { "type": "string", "format": "date-time" },
+        "ttl-hours": { "type": "integer", "minimum": 1 },
+        "kernel-wallet": {
+          "type": "string",
+          "pattern": "^0x[0-9a-fA-F]{40}$",
+          "description": "MUST equal agent.kernel-wallet."
+        }
+      }
+    },
+    "revocation": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["mechanism", "procedure", "verification"],
+      "properties": {
+        "mechanism": {
+          "type": "string",
+          "const": "version-bump-and-rotate",
+          "description": "v1 supports only this mechanism. Future versions MAY add reputation-list or on-chain registry hooks."
+        },
+        "procedure": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "type": "string" },
+          "description": "Ordered prose steps the owner follows to revoke + rotate."
+        },
+        "verification": {
+          "type": "string",
+          "description": "How a third party verifies a signature against the live policy. e.g. 'Fetch ipfs://<CID> via the `delegation` ENS record; assert keccak256 of canonical bytes equals `policy-hash`; confirm signer matches `runtime-pubkey`.'"
+        }
+      }
+    }
+  }
+}

--- a/packages/resolver/test/fixtures/agent-verify/delegation-policy-v1.json
+++ b/packages/resolver/test/fixtures/agent-verify/delegation-policy-v1.json
@@ -1,0 +1,62 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://emilemarcelagustin.eth.limo/policies/delegation-policy-v1.json",
+  "schema-uri": "https://emilemarcelagustin.eth.limo/schemas/delegation-policy-schema-v1.json",
+  "agent": {
+    "ens-name": "emilemarcelagustin.eth",
+    "agent-id": 24994,
+    "kernel-wallet": "0xEc0d3C782C6087235Ab16d8c4d4188d10DFD796A",
+    "chain": "base-mainnet",
+    "chain-id": 8453
+  },
+  "version": "v1",
+  "issued-at": "2026-05-04T22:48:00Z",
+  "delegators": [
+    {
+      "label": "owner-eoa",
+      "address": "0xeb0ABB367540f90B57b3d5719fd2b9c740a15022",
+      "ens": null,
+      "role": "primary"
+    },
+    {
+      "label": "estmcmxci.eth",
+      "address": "0x703ae03fB120eC91e9Ed6d08Ce8044E498CC789B",
+      "ens": "estmcmxci.eth",
+      "role": "co-authority"
+    }
+  ],
+  "delegation-policy": {
+    "threshold": "1-of-2",
+    "scope": ["eip191-sign", "eip712-sign"],
+    "ttl-hours": 168,
+    "permitted-message-classes": [
+      "identity-attestation",
+      "agent-action-receipt",
+      "ensip-25-proof",
+      "ensip-26-endpoint-proof"
+    ],
+    "prohibited": [
+      "userop-broadcast",
+      "value-transfer",
+      "contract-write"
+    ]
+  },
+  "active-session-key": {
+    "address": "0x8973B6897554017d208DBeE2Ef5Fb8Fb046A6aEB",
+    "issued-at": "2026-05-04T22:00:00Z",
+    "ttl-hours": 168,
+    "kernel-wallet": "0xEc0d3C782C6087235Ab16d8c4d4188d10DFD796A"
+  },
+  "revocation": {
+    "mechanism": "version-bump-and-rotate",
+    "procedure": [
+      "Owner generates a new session key locally via the Namera CLI (issue-session-key), keystore-encrypted on the operator host. The owner key never leaves the operator host.",
+      "Owner authors delegation-policy-vN.json with bumped version, new active-session-key.address, and refreshed issued-at timestamp.",
+      "Owner pins the new policy to IPFS (Pinata directory pin under spec/ipfs) and computes its keccak256 hash over the pinned bytes.",
+      "Owner publishes three ENS text records on emilemarcelagustin.eth in a single batch: delegation = ipfs://<new-CID>/policies/delegation-policy-vN.json, policy-hash = 0x<keccak256>, policy-version = vN.",
+      "Owner rotates runtime-pubkey on ENS to the new session-key address; the runtime daemon's NAMERA_SESSION_KEY_BLOB and NAMERA_SESSION_KEY_PASSWORD secrets are updated and the daemon restarted.",
+      "The previous session key is now revoked: any signature it produces no longer matches runtime-pubkey on ENS and MUST be rejected by verifiers."
+    ],
+    "verification": "Fetch ipfs://<CID>/policies/delegation-policy-vN.json via the `delegation` ENS text record on emilemarcelagustin.eth. Compute keccak256 of the canonical UTF-8 bytes of the fetched document and assert equality with the `policy-hash` ENS text record. Verify the signer of any incoming attestation matches the `runtime-pubkey` ENS text record AND the `active-session-key.address` field in the fetched policy. Reject any signature whose payload class is not listed in `delegation-policy.permitted-message-classes`, or that performs any action listed in `delegation-policy.prohibited`."
+  }
+}

--- a/packages/resolver/test/fixtures/agent-verify/records.json
+++ b/packages/resolver/test/fixtures/agent-verify/records.json
@@ -1,0 +1,19 @@
+{
+  "_comment": "Frozen ENSIP-64 text records for emilemarcelagustin.eth. Source: canonical tuple in agency repo (deploy/ens-agent/.env.deploy + memory note). Frozen 2026-05-05 for offline test fixtures.",
+  "ensName": "emilemarcelagustin.eth",
+  "ownerAddress": "0xeb0ABB367540f90B57b3d5719fd2b9c740a15022",
+  "agentId": "24994",
+  "registryChain": "eip155:8453",
+  "registryAddress": "0x8004A169FB4a3325136EB29fA0ceB6D2e539a432",
+  "records": {
+    "class": "Agent",
+    "schema": "ipfs://bafybeighgfsdllcwlb7uvga5foqonx52vnoryede72jo6k2a4rtj5naq3i/schemas/agent-schema-v1.json",
+    "runtime-pubkey": "0x8973B6897554017d208DBeE2Ef5Fb8Fb046A6aEB",
+    "runtime-status": "active",
+    "kernel-wallet": "0xEc0d3C782C6087235Ab16d8c4d4188d10DFD796A",
+    "agent-endpoint[web]": "https://xxje1rfb.agents.pinata.cloud/app",
+    "delegation": "ipfs://bafybeicqnxyjsvro7ipmdhhzymtk5y2qbaudzmtgggllt7midikdxkmoxi/policies/delegation-policy-v1.json",
+    "policy-hash": "0x6f3878cb630f8d16e5f8eac858f8923d15d5475773c1205b97dab0b06b35c114",
+    "policy-version": "v1"
+  }
+}

--- a/plans/ensemble-agent-verify.md
+++ b/plans/ensemble-agent-verify.md
@@ -1,0 +1,97 @@
+# Plan: `ensemble agent verify <ens-name>`
+
+First slice of the Ensemble-CLI-as-deploy-tool path. Ports the five-step
+ENSIP-64 agent verification flow into a generic CLI command + library
+function so any third-party verifier (or the synthesis explorer route, when
+that ships) can assert that a signed action originated from an ENS-bound
+agent operating within its published policy.
+
+This PR ships **verification only** — no key generation, no IPFS pinning,
+no record publishing.
+
+## Scope
+
+### In
+
+- New CLI subcommand `ensemble agent verify <ens-name>`
+- Library function `verifyAgentIdentity(ensName, options)` exported from `@synthesis/resolver`
+- IPFS doc fetch with multi-gateway race
+- RFC 8785 JCS canonicalization + `keccak256`
+- JSON-Schema 2020-12 validation against the agent + delegation-policy schemas
+- HTTP `/health` probe; optional `/sign` challenge with `--probe-sign`
+- EIP-191 signer recovery; equality assertion against `runtime-pubkey`
+- Human and `--format json` output
+- Stable `AgentVerifyErrorCode` enum per layer
+
+### Out (separate PRs)
+
+- ERC-8004 trust-tier wiring for `ensemble trust` (#43)
+- `ensemble agent issue / pin / publish / rotate`
+- Synthesis explorer route at `/agent/<ens-name>` (#44)
+
+## CLI surface
+
+```
+ensemble agent verify emilemarcelagustin.eth
+ensemble agent verify emilemarcelagustin.eth --probe-sign
+ensemble agent verify emilemarcelagustin.eth --format json
+ensemble agent verify emilemarcelagustin.eth --rpc https://eth.llamarpc.com
+ensemble agent verify emilemarcelagustin.eth --ipfs-gateway https://my-gw/ipfs/ --ipfs-gateway https://w3s.link/ipfs/
+```
+
+| Flag | Default | Meaning |
+|---|---|---|
+| `--probe-sign` | off | POST a challenge to `<endpoint>/sign`, recover signer, assert equality with `runtime-pubkey` |
+| `--ipfs-gateway` | w3s.link, gateway.pinata.cloud, cloudflare-ipfs.com, ipfs.io | Repeatable; first 200 wins |
+| `--rpc` | `$ETH_RPC_URL` or `https://eth.drpc.org` | ENS-mainnet RPC URL |
+| `--timeout` | 10000 | Per-network-call timeout (ms) |
+| `--format json` | — | Emit structured `AgentVerifyResult` on stdout |
+| `--explain` | off | Print debug detail per layer |
+
+## Layered checks
+
+1. **Records** — read 9 ENSIP-64 keys, assert presence + regex-typed values
+2. **Schema** — fetch + parse `agent-schema-v1.json`, validate the records doc
+3. **Integrity** — `keccak256(JCS(policy-doc)) == policy-hash`
+4. **Binding** — `policy.active-session-key.address == runtime-pubkey`; kernel + ens-name match
+5. **Liveness** — `GET <endpoint>/health` returns 200
+6. **Signature** *(optional, `--probe-sign`)* — POST `{nonce, issuedAt, verifierId}`, recover EIP-191 signer
+
+Exit codes: 0 verified, 1 layer failure, 2 input error.
+
+## Files
+
+| File | Status |
+|---|---|
+| `packages/resolver/src/layers/agent-verify.ts` | new — core orchestrator + `AgentVerifyErrorCode` enum |
+| `packages/resolver/src/layers/agent-verify.test.ts` | new — 9 unit tests, all offline against frozen fixtures |
+| `packages/resolver/src/utils/jcs.ts` | new — RFC 8785 JCS |
+| `packages/resolver/src/utils/jcs.test.ts` | new — RFC 8785 fixtures + on-chain hash assertion |
+| `packages/resolver/src/utils/agent-schema-validator.ts` | new — hand-rolled JSON-Schema 2020-12 subset |
+| `packages/resolver/src/utils/ipfs.ts` | edit — adds `fetchIpfsRaw` race helper, preserves existing fetchers |
+| `packages/resolver/src/index.ts` | edit — re-export verifier API |
+| `packages/resolver/test/fixtures/agent-verify/` | new — frozen schemas + policy + records, no network |
+| `packages/cli/commands/agent-verify.ts` | new — CLI presenter + `formatResult` + `exitCodeFor` |
+| `packages/cli/commands/agent-verify.test.ts` | new — 5 unit tests (output shape + exit codes) |
+| `packages/cli/commands/index.ts` | edit — barrel export |
+| `packages/cli/index.ts` | edit — register `agent verify` subcommand |
+
+## Decisions on the §8 open questions
+
+1. **Sub-command grouping pattern** — used the existing incur sub-command group (`agent.command("verify", …)` then `cli.command(agent)`); same shape as the existing `agent register / link / info`.
+2. **Validator** — hand-rolled. Synthesis pulls no Ajv (transitive or direct), and zod isn't a JSON-Schema 2020-12 validator. ~120 LOC covers the keywords used by the agent + delegation-policy schemas.
+3. **IPFS gateways** — public gateway list (w3s.link, gateway.pinata.cloud, cloudflare-ipfs.com, ipfs.io). Caller can override with repeatable `--ipfs-gateway`. First-200-wins race via `Promise.any`.
+4. **Stable error-code enum** — yes, `AgentVerifyErrorCode` enum is defined and surfaced in JSON output for every layer.
+5. **`probe-sign` envelope** — `{ nonce: 0x<32 hex>, issuedAt: ISO8601, verifierId: "ensemble-cli/agent-verify@v1" }`. Daemon signs `JCS(envelope)` as the EIP-191 message.
+
+## Acceptance
+
+```bash
+pnpm install
+pnpm -r build
+pnpm -r test
+node packages/cli/dist/index.js agent verify emilemarcelagustin.eth
+node packages/cli/dist/index.js agent verify emilemarcelagustin.eth --format json
+```
+
+Reference deployment: `emilemarcelagustin.eth` (live, all 9 ENSIP-64 records on mainnet).


### PR DESCRIPTION
## Summary

- New CLI subcommand `ensemble agent verify <ens-name>` and library function `verifyAgentIdentity` exported from `@synthesis/resolver`. Runs 5 layered checks (+ optional 6th with `--probe-sign`) over a TRL-style identity card.
- All 6 layers pass live against the reference deployment (`emilemarcelagustin.eth`).
- 36 resolver + 5 CLI unit tests, all offline against frozen fixtures.

Closes #45.

## What it does

Reads 9 ENSIP-64 text records from an ENS name, fetches the agent + policy schemas + the policy doc itself from IPFS, then runs:

1. **Records** — 9 keys present + regex-typed (class, schema, runtime-pubkey, runtime-status, kernel-wallet, agent-endpoint[web], delegation, policy-hash, policy-version).
2. **Schema** — agent records validate against `agent-schema-v1.json` (JSON Schema 2020-12).
3. **Integrity** — `keccak256(JCS(policy-doc)) == policy-hash`.
4. **Binding** — `policy.active-session-key.address == runtime-pubkey`; `kernel-wallet` matches across record/policy.agent/active-session-key; `policy.agent.ens-name == <name>`.
5. **Liveness** — `GET <agent-endpoint[web]>/health` returns 200.
6. **Signature** *(optional, `--probe-sign`)* — POST `{message: JCS({nonce, issuedAt, verifierId})}` to `/sign`, recover EIP-191 signer, assert equality with `runtime-pubkey`.

Exit codes: `0` verified, `1` any layer failed, `2` input error (incur native).

## Resolutions to the §8 maintainer questions

The plan doc enumerates 5 open questions for maintainers — answers I locked in before coding so reviewers don't have to re-derive them:

1. **Sub-command grouping pattern** — used the existing incur sub-command group: `agent.command(\"verify\", …)` then `cli.command(agent)`. Same shape as the existing `agent register / link / info`. No new framework dependency.

2. **Validator: zod vs Ajv vs hand-rolled** — **hand-rolled**. Reasoning made explicit because the original plan suggested Ajv: synthesis pulls **no Ajv** (transitive or direct), and **zod isn't a JSON-Schema 2020-12 validator** — it can't ingest the JSON-Schema docs the agent + delegation-policy schemas are authored in. The two schemas use only ~10 keywords (type, const, enum, pattern, format, required, properties, additionalProperties, items, minItems/maxItems, minimum/maximum, minLength/maxLength); a 100-LOC validator at `packages/resolver/src/utils/agent-schema-validator.ts` covers them and avoids a top-level dep. If a future schema needs `$ref`/`oneOf`/`allOf`/etc., swap to Ajv at that point.

3. **Default IPFS gateway list** — multi-gateway race via `Promise.any`, first 200 wins. Default order: w3s.link, gateway.pinata.cloud, cloudflare-ipfs.com, ipfs.io. Caller can fully override via repeatable `--ipfs-gateway`.

4. **Stable error-code enum per layer** — yes. Defined `AgentVerifyErrorCode` (e.g. `RECORDS_MISSING`, `INTEGRITY_HASH_MISMATCH`, `BINDING_SESSION_KEY_MISMATCH`, `SIGNATURE_RECOVER_MISMATCH`) and surfaced in every layer of the JSON output for downstream UI rendering.

5. **`probe-sign` envelope** — defined here, not deferred. Verifier-side: `{nonce: 0x<32 hex chars>, issuedAt: ISO8601, verifierId: \"ensemble-cli/agent-verify@v1\"}`. Wire format: `POST /sign` with `{message: JCS(envelope)}`; the daemon EIP-191 signs the message string, returns `{signature, ...}`. The verifier reproduces the same canonical-string locally for `recoverMessageAddress`.

## Live run

```
$ ensemble agent verify emilemarcelagustin.eth --probe-sign

  Identity Card
  ─────────────
    ENS name        : emilemarcelagustin.eth
    Owner           : 0xeb0ABB367540f90B57b3d5719fd2b9c740a15022
    Kernel wallet   : 0xEc0d3C782C6087235Ab16d8c4d4188d10DFD796A
    Runtime pubkey  : 0x8973B6897554017d208DBeE2Ef5Fb8Fb046A6aEB
    Endpoint        : https://xxje1rfb.agents.pinata.cloud/app

  Layered Verification
  ────────────────────
  ✓ Records       : 9/9 ENSIP-64 keys present and well-typed
  ✓ Schema        : validated against ipfs://bafybeighgfsdll…/schemas/agent-schema-v1.json
  ✓ Integrity     : keccak256(JCS(policy)) == 0x6f3878cb...
  ✓ Binding       : active-session-key.address matches runtime-pubkey
  ✓ Liveness      : GET /health → HTTP 200
  ✓ Signature     : recovered 0x8973B689… == runtime-pubkey

  Result: VERIFIED ✓
```

## JCS-correctness anchor

The most important byte-level test: the frozen `delegation-policy-v1.json` fixture, when run through `canonicalize()` and hashed, must produce **exactly** `0x6f3878cb630f8d16e5f8eac858f8923d15d5475773c1205b97dab0b06b35c114` — the published `policy-hash` ENS text record. `jcs.test.ts` asserts this. If a future change breaks the canonicalizer, this test fails immediately and points the reader at the on-chain divergence.

## Files

| File | Status |
|---|---|
| `packages/resolver/src/layers/agent-verify.{ts,test.ts}` | new — orchestrator + 9 unit tests |
| `packages/resolver/src/utils/jcs.{ts,test.ts}` | new — RFC 8785 + on-chain hash assertion |
| `packages/resolver/src/utils/agent-schema-validator.ts` | new — hand-rolled JSON-Schema 2020-12 subset |
| `packages/resolver/src/utils/ipfs.ts` | edit — adds `fetchIpfsRaw` race helper, preserves existing fetchers |
| `packages/resolver/src/index.ts` | edit — re-export verifier API + `canonicalize` helpers |
| `packages/resolver/test/fixtures/agent-verify/` | new — 4 frozen files + README documenting source CIDs and freeze date |
| `packages/cli/commands/agent-verify.{ts,test.ts}` | new — presenter + 5 unit tests (output shape + exit codes) |
| `packages/cli/commands/index.ts`, `packages/cli/index.ts` | edit — wire `agent verify` subcommand |
| `packages/{resolver,cli}/package.json` | edit — fix `test` glob to include `src/layers/*.test.ts` (resolver) and add a `test` script (cli) |
| `plans/ensemble-agent-verify.md` | new — short plan, lifted from the agency-side doc |

## Test plan

- [x] `pnpm -r test` — 36 resolver + 5 CLI tests pass (offline)
- [x] `pnpm -r build` — clean
- [x] `pnpm typecheck` — clean
- [x] Live run: `node packages/cli/dist/index.js agent verify emilemarcelagustin.eth` — all 5 layers ✓
- [x] Live run: `--probe-sign` — 6th layer ✓ (recovered signer matches `runtime-pubkey`)
- [x] Live run: `--format json` — clean structured output, no human-format leakage
- [x] Negative: `node packages/cli/dist/index.js agent verify vitalik.eth` — fails records layer cleanly with stable error codes
- [ ] (deferred until `agent issue` PR) Behavior under runtime-status = paused/revoked

## Out of scope (separate PRs)

- ERC-8004 trust-tier wiring for `ensemble trust` (#43)
- `ensemble agent issue / pin / publish / rotate`
- Synthesis explorer route at `/agent/<ens-name>` (#44 — depends on this PR's `--format json`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)