### PR TITLE
fix(resolver): identity layer auto-discovers agent IDs from agent-ids index (closes #43)

### DIFF
--- a/packages/resolver/src/layers/identity.test.ts
+++ b/packages/resolver/src/layers/identity.test.ts
@@ -1,0 +1,123 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { resolveIdentity } from "./identity.js";
+import { KNOWN_REGISTRIES, buildEnsip25Key } from "../utils/erc7930.js";
+
+const BASE = KNOWN_REGISTRIES["8004-base"];
+
+function records(map: Record<string, string>) {
+  return async (_ens: string, key: string) => map[key] ?? null;
+}
+
+const happyOnChain = async () => ({
+  tokenURI: "data:application/json;base64,eyJuYW1lIjoidGVzdCJ9",
+  owner: "0xeb0ABB367540f90B57b3d5719fd2b9c740a15022",
+});
+
+test("auto-discovery — agent-ids index alone is enough to verify identity (regression for #43)", async () => {
+  // The headline bug from #43: passing no knownAgentIds resulted in an empty
+  // scan loop. With the agent-ids index in place, identity must verify.
+  const ensip25Key = buildEnsip25Key(BASE.chainId, BASE.address, "24994");
+  const result = await resolveIdentity("emilemarcelagustin.eth", undefined, {
+    registries: [{ chainId: BASE.chainId, address: BASE.address }],
+    testHooks: {
+      readTextRecord: records({
+        "agent-ids": '["24994"]',
+        [ensip25Key]: "1",
+      }),
+      verifyOnChain: happyOnChain,
+    },
+  });
+  assert.equal(result.verified, true);
+  assert.equal(result.agentId, "24994");
+  assert.equal(result.registryChain, `eip155:${BASE.chainId}`);
+});
+
+test("auto-discovery still works when knownAgentIds is also supplied — caller IDs and indexed IDs are merged", async () => {
+  const ensip25Key = buildEnsip25Key(BASE.chainId, BASE.address, "24994");
+  const result = await resolveIdentity("emilemarcelagustin.eth", ["999", "24994"], {
+    registries: [{ chainId: BASE.chainId, address: BASE.address }],
+    testHooks: {
+      readTextRecord: records({
+        "agent-ids": '["24994"]',
+        [ensip25Key]: "1",
+      }),
+      verifyOnChain: happyOnChain,
+    },
+  });
+  assert.equal(result.verified, true);
+  assert.equal(result.agentId, "24994");
+});
+
+test("malformed agent-ids JSON degrades to using only knownAgentIds, doesn't throw", async () => {
+  const ensip25Key = buildEnsip25Key(BASE.chainId, BASE.address, "777");
+  const result = await resolveIdentity("name.eth", ["777"], {
+    registries: [{ chainId: BASE.chainId, address: BASE.address }],
+    testHooks: {
+      readTextRecord: records({
+        "agent-ids": "not-valid-json{",
+        [ensip25Key]: "1",
+      }),
+      verifyOnChain: happyOnChain,
+    },
+  });
+  assert.equal(result.verified, true);
+  assert.equal(result.agentId, "777");
+});
+
+test("non-array agent-ids JSON also degrades — array is required", async () => {
+  const result = await resolveIdentity("name.eth", undefined, {
+    registries: [{ chainId: BASE.chainId, address: BASE.address }],
+    testHooks: {
+      readTextRecord: records({
+        "agent-ids": '{"some": "object"}',
+      }),
+    },
+  });
+  assert.equal(result.verified, false);
+  assert.equal(result.agentId, null);
+});
+
+test("array entries that aren't strings are filtered out", async () => {
+  const ensip25Key = buildEnsip25Key(BASE.chainId, BASE.address, "5");
+  const result = await resolveIdentity("name.eth", undefined, {
+    registries: [{ chainId: BASE.chainId, address: BASE.address }],
+    testHooks: {
+      readTextRecord: records({
+        "agent-ids": '[null, 42, "5", ""]',
+        [ensip25Key]: "1",
+      }),
+      verifyOnChain: happyOnChain,
+    },
+  });
+  assert.equal(result.verified, true);
+  assert.equal(result.agentId, "5");
+});
+
+test("no agent-ids record and no knownAgentIds — returns verified:false cleanly", async () => {
+  const result = await resolveIdentity("vitalik.eth", undefined, {
+    registries: [{ chainId: BASE.chainId, address: BASE.address }],
+    testHooks: {
+      readTextRecord: records({}),
+    },
+  });
+  assert.equal(result.verified, false);
+  assert.equal(result.agentId, null);
+  assert.equal(result.registryChain, null);
+});
+
+test("agent-ids has an ID but ENSIP-25 record is missing — does not falsely verify", async () => {
+  // Defends against a stale agent-ids index that lists IDs whose ENSIP-25
+  // text records have been deleted or never written.
+  const result = await resolveIdentity("stale.eth", undefined, {
+    registries: [{ chainId: BASE.chainId, address: BASE.address }],
+    testHooks: {
+      readTextRecord: records({
+        "agent-ids": '["24994"]',
+        // no ENSIP-25 key — discovery must not assume the link is live
+      }),
+      verifyOnChain: happyOnChain,
+    },
+  });
+  assert.equal(result.verified, false);
+});

--- a/packages/resolver/src/layers/identity.test.ts
+++ b/packages/resolver/src/layers/identity.test.ts
@@ -147,6 +147,27 @@ test("agent-ids index with a stale id followed by a fresh one — scan continues
   assert.equal(result.agentId, "24994");
 });
 
+test("testHooks without verifyOnChain — never hits the network, returns verified:false (Codex P2)", async () => {
+  // The testHooks contract guarantees no live network calls. A partial
+  // stub (readTextRecord only, no verifyOnChain) must not silently fall
+  // back to real RPC the moment an ENSIP-25 record matches. Default
+  // behavior: treat the missing hook as if on-chain verification failed
+  // (null fields), so the caller gets a clean verified:false.
+  const ensip25Key = buildEnsip25Key(BASE.chainId, BASE.address, "24994");
+  const result = await resolveIdentity("emilemarcelagustin.eth", undefined, {
+    registries: [{ chainId: BASE.chainId, address: BASE.address }],
+    testHooks: {
+      readTextRecord: records({
+        "agent-ids": '["24994"]',
+        [ensip25Key]: "1",
+      }),
+      // verifyOnChain intentionally omitted
+    },
+  });
+  assert.equal(result.verified, false);
+  assert.equal(result.agentId, null);
+});
+
 test("agent-ids has an ID but ENSIP-25 record is missing — does not falsely verify", async () => {
   // Defends against a stale agent-ids index that lists IDs whose ENSIP-25
   // text records have been deleted or never written.

--- a/packages/resolver/src/layers/identity.test.ts
+++ b/packages/resolver/src/layers/identity.test.ts
@@ -106,6 +106,47 @@ test("no agent-ids record and no knownAgentIds — returns verified:false cleanl
   assert.equal(result.registryChain, null);
 });
 
+test("ENSIP-25 record present but on-chain verifyOnChain returns null — does not falsely verify (Codex P1)", async () => {
+  // Defends against a stale/burned token id where the link record exists on
+  // ENS but the ERC-8004 contract no longer recognizes the agent (or the RPC
+  // is transiently failing). Without this gate, agent-ids auto-discovery
+  // could elevate trust based purely on the ENS text record.
+  const ensip25Key = buildEnsip25Key(BASE.chainId, BASE.address, "24994");
+  const result = await resolveIdentity("emilemarcelagustin.eth", undefined, {
+    registries: [{ chainId: BASE.chainId, address: BASE.address }],
+    testHooks: {
+      readTextRecord: records({
+        "agent-ids": '["24994"]',
+        [ensip25Key]: "1",
+      }),
+      verifyOnChain: async () => ({ tokenURI: null, owner: null }),
+    },
+  });
+  assert.equal(result.verified, false);
+  assert.equal(result.agentId, null);
+});
+
+test("agent-ids index with a stale id followed by a fresh one — scan continues past the stale entry", async () => {
+  const staleKey = buildEnsip25Key(BASE.chainId, BASE.address, "999");
+  const freshKey = buildEnsip25Key(BASE.chainId, BASE.address, "24994");
+  const result = await resolveIdentity("emilemarcelagustin.eth", undefined, {
+    registries: [{ chainId: BASE.chainId, address: BASE.address }],
+    testHooks: {
+      readTextRecord: records({
+        "agent-ids": '["999", "24994"]',
+        [staleKey]: "1",
+        [freshKey]: "1",
+      }),
+      verifyOnChain: async (_reg, id) =>
+        id === "24994"
+          ? { tokenURI: "data:application/json;base64,e30=", owner: "0xeb0A" }
+          : { tokenURI: null, owner: null },
+    },
+  });
+  assert.equal(result.verified, true);
+  assert.equal(result.agentId, "24994");
+});
+
 test("agent-ids has an ID but ENSIP-25 record is missing — does not falsely verify", async () => {
   // Defends against a stale agent-ids index that lists IDs whose ENSIP-25
   // text records have been deleted or never written.

--- a/packages/resolver/src/layers/identity.ts
+++ b/packages/resolver/src/layers/identity.ts
@@ -130,8 +130,16 @@ export async function resolveIdentity(
         // would let a stale `agent-ids` index falsely elevate trust. If
         // this entry doesn't verify cleanly, `continue` so the scan can
         // still find a valid (registry, id) pair further down the index.
-        const onChain = options.testHooks?.verifyOnChain
-          ? await options.testHooks.verifyOnChain(registry, agentId)
+        //
+        // When `testHooks` is set, the contract is "no live network calls".
+        // If the caller stubs `readTextRecord` but not `verifyOnChain`,
+        // default to a null-returning stub rather than dropping into real
+        // RPC — otherwise a partially-stubbed test would silently hit the
+        // network the moment any ENSIP-25 record matched.
+        const onChain = options.testHooks
+          ? options.testHooks.verifyOnChain
+            ? await options.testHooks.verifyOnChain(registry, agentId)
+            : { tokenURI: null, owner: null }
           : await verifyOnChain(registry, agentId);
         if (onChain.tokenURI === null || onChain.owner === null) {
           continue;

--- a/packages/resolver/src/layers/identity.ts
+++ b/packages/resolver/src/layers/identity.ts
@@ -55,25 +55,35 @@ const CHAIN_MAP: Record<number, typeof base> = {
 export interface ResolveIdentityOptions {
   registries?: RegistryTarget[];
   ensRpcUrl?: string;
+  /**
+   * Inject text-record reads + on-chain verification for tests. When
+   * provided, no live network calls are made. The test hook receives the
+   * ENS name and key (e.g. `agent-ids`, `agent-registration[…][…]`) and
+   * should return the record value or null.
+   */
+  testHooks?: {
+    readTextRecord: (ensName: string, key: string) => Promise<string | null>;
+    verifyOnChain?: (
+      registry: RegistryTarget,
+      agentId: string,
+    ) => Promise<{ tokenURI: string | null; owner: string | null }>;
+  };
 }
 
 /**
  * Resolve ENSIP-25 identity for an ENS name.
  *
- * For each known registry, constructs all possible ENSIP-25 keys
- * (scanning agent IDs from text records), checks if the record is set,
- * and verifies the agent on-chain.
+ * Discovery: ENS exposes no text-record enumeration, so the resolver can't
+ * iterate over `agent-registration[<reg>][<id>]` keys directly. Instead, we
+ * use the `agent-ids` text record as an on-chain index of all agent IDs
+ * linked to this name — the same record `ensemble agent link` writes when
+ * publishing an ENSIP-25 record. Format: a JSON array of agent-ID strings,
+ * e.g. `["24994"]`. IDs supplied by the caller via `knownAgentIds` are
+ * merged on top of the index, so callers can still pre-seed when the index
+ * isn't published yet.
  *
- * Since we don't know the agent ID upfront, we scan by checking known
- * agent IDs from the ENS name's text records. The approach:
- * 1. For each registry, build the ERC-7930 prefix
- * 2. Try to find an agent-registration text record by scanning known IDs
- *    or by using a wildcard approach
- *
- * In practice, the resolver is given a name and must discover the agent ID.
- * We do this by scanning text record keys that match the ENSIP-25 pattern.
- * Since viem can't enumerate text records, we try known agent IDs if provided,
- * or fall back to scanning a reasonable range.
+ * For each (registry × agentId) pair we build the ENSIP-25 key, look it up
+ * as a text record, and verify the agent on-chain via tokenURI + ownerOf.
  */
 export async function resolveIdentity(
   ensName: string,
@@ -81,18 +91,42 @@ export async function resolveIdentity(
   options: ResolveIdentityOptions = {},
 ): Promise<IdentityResult> {
   const registries = options.registries ?? DEFAULT_REGISTRIES;
-  const ensClient = createEnsClient(options.ensRpcUrl);
+  const readText = options.testHooks
+    ? options.testHooks.readTextRecord
+    : (() => {
+        const ensClient = createEnsClient(options.ensRpcUrl);
+        return (name: string, key: string) => getTextRecord(ensClient, name, key);
+      })();
+
+  // Auto-discover agent IDs from the canonical `agent-ids` text record.
+  // Best-effort: a malformed value or RPC error degrades to using only the
+  // caller-supplied IDs rather than failing the whole layer.
+  const indexed: string[] = [];
+  const indexRaw = await readText(ensName, "agent-ids");
+  if (indexRaw) {
+    try {
+      const parsed = JSON.parse(indexRaw);
+      if (Array.isArray(parsed)) {
+        for (const id of parsed) {
+          if (typeof id === "string" && id.length > 0) indexed.push(id);
+        }
+      }
+    } catch {
+      // Non-JSON values are treated as no index — write side enforces JSON.
+    }
+  }
+  const merged = Array.from(new Set([...indexed, ...(knownAgentIds ?? [])]));
 
   for (const registry of registries) {
-    const agentIds = knownAgentIds ?? [];
-
-    for (const agentId of agentIds) {
+    for (const agentId of merged) {
       const key = buildEnsip25Key(registry.chainId, registry.address, agentId);
-      const value = await getTextRecord(ensClient, ensName, key);
+      const value = await readText(ensName, key);
 
       if (value && value.length > 0) {
         // Found an ENSIP-25 record — verify on-chain
-        const onChain = await verifyOnChain(registry, agentId);
+        const onChain = options.testHooks?.verifyOnChain
+          ? await options.testHooks.verifyOnChain(registry, agentId)
+          : await verifyOnChain(registry, agentId);
         const erc7930 = encodeErc7930Address(registry.chainId, registry.address);
 
         return {

--- a/packages/resolver/src/layers/identity.ts
+++ b/packages/resolver/src/layers/identity.ts
@@ -123,10 +123,19 @@ export async function resolveIdentity(
       const value = await readText(ensName, key);
 
       if (value && value.length > 0) {
-        // Found an ENSIP-25 record — verify on-chain
+        // Found an ENSIP-25 record — verify on-chain. Both `tokenURI` and
+        // `owner` must read successfully before we elevate to verified.
+        // verifyOnChain returns null fields for burned/nonexistent token
+        // IDs OR for transient RPC failures; treating either as a pass
+        // would let a stale `agent-ids` index falsely elevate trust. If
+        // this entry doesn't verify cleanly, `continue` so the scan can
+        // still find a valid (registry, id) pair further down the index.
         const onChain = options.testHooks?.verifyOnChain
           ? await options.testHooks.verifyOnChain(registry, agentId)
           : await verifyOnChain(registry, agentId);
+        if (onChain.tokenURI === null || onChain.owner === null) {
+          continue;
+        }
         const erc7930 = encodeErc7930Address(registry.chainId, registry.address);
 
         return {


### PR DESCRIPTION
## Summary

Fixes the identity layer's silent failure mode for any caller who doesn't already know the agent ID. Closes #43.

## Before / after

`emilemarcelagustin.eth` is a registered agent (ERC-8004 #24994 on Base). Trust resolution today:

```
$ ensemble trust emilemarcelagustin.eth
  ✓ Personhood: World ID, ...
  ✗ Identity: no ENSIP-25 registration found        ← bug
  ✓ Context: ENSIP-26, SKILL.md at ...
  ...
  Trust Tier: none
```

After this PR:

```
$ ensemble trust emilemarcelagustin.eth
  ✓ Personhood: World ID, ...
  ✓ Identity: ERC-8004 #24994, eip155:8453          ← fixed
  ✓ Context: ENSIP-26, SKILL.md at ...
  ✓ Manifest: AIP v1, signature valid
  ✓ Skill: domain-verified
  Trust Tier: full
```

## Root cause

`packages/resolver/src/layers/identity.ts:87`:

```ts
const agentIds = knownAgentIds ?? [];
```

If the caller passed no IDs (the common case), the inner scan loop iterated over an empty array and the function fell through to `verified: false`. A code comment promised "fall back to scanning a reasonable range" — that fallback never existed.

## Fix

Read the canonical `agent-ids` ENS text record (a JSON array of agent-ID strings, e.g. `["24994"]`) and merge it with caller-supplied IDs before scanning. This is the same record `ensemble agent link` already writes when publishing an ENSIP-25 record (see #40), so for any name linked through Ensemble, identity now resolves automatically.

```ts
const indexed: string[] = [];
const indexRaw = await readText(ensName, "agent-ids");
if (indexRaw) {
  try {
    const parsed = JSON.parse(indexRaw);
    if (Array.isArray(parsed)) {
      for (const id of parsed) {
        if (typeof id === "string" && id.length > 0) indexed.push(id);
      }
    }
  } catch { /* malformed → degrade, don't throw */ }
}
const merged = Array.from(new Set([...indexed, ...(knownAgentIds ?? [])]));
```

Best-effort: a malformed value or RPC error degrades to using only the caller-supplied IDs rather than failing the whole layer.

## Naming choice — `agent-ids` (plural) vs the issue's `agent-id`

The issue (#43) proposed `agent-id` as a comma-separated string. I went with **`agent-ids`** (plural, JSON array) because that's the record name Ensemble's write side has already standardized on (PR #40, `agent.ts:link()`). Using a different key here would create a write/read mismatch where `agent link` writes one record and `trust` reads another.

## Test plan

- [x] `pnpm -r test` — 45 resolver + 7 CLI tests pass (offline)
- [x] `pnpm -r build` — clean
- [x] Live: `ensemble trust emilemarcelagustin.eth` → `Trust Tier: full` (was `none`)
- [x] +7 new unit cases in `identity.test.ts`:
  - Regression for #43: agent-ids index alone is enough to verify
  - Caller IDs and indexed IDs are merged
  - Malformed JSON degrades to caller IDs without throwing
  - Non-array JSON is treated as no index
  - Non-string array entries are filtered out
  - No index + no caller IDs returns `verified: false` cleanly
  - Stale index (ENSIP-25 record missing) does NOT falsely verify

## Files

| File | Change |
|---|---|
| `packages/resolver/src/layers/identity.ts` | edit — auto-discovery, optional `testHooks`, comment rewrite |
| `packages/resolver/src/layers/identity.test.ts` | new — 7 unit tests |

🤖 Generated with [Claude Code](https://claude.com/claude-code)