### PR TITLE
feat(cli,resolver): ensemble agent pin <dir> — Pinata pinning + policy-hash (closes #48)

### DIFF
--- a/packages/cli/commands/agent-pin.test.ts
+++ b/packages/cli/commands/agent-pin.test.ts
@@ -1,0 +1,241 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, writeFileSync, mkdirSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { agentPin } from "./agent-pin";
+
+const FAKE_CID = "bafybeicqnxyjsvro7ipmdhhzymtk5y2qbaudzmtgggllt7midikdxkmoxi";
+
+/**
+ * The CLI presenter calls into @synthesis/resolver's pinDirectory which
+ * uses globalThis.fetch. To test offline we monkey-patch globalThis.fetch
+ * for the duration of the test (and restore after).
+ */
+async function withMockedFetch<T>(
+  responder: (url: string, init?: RequestInit) => Response | Promise<Response>,
+  fn: () => Promise<T>,
+): Promise<T> {
+  const original = globalThis.fetch;
+  globalThis.fetch = (async (input: string | URL | Request, init?: RequestInit) =>
+    responder(typeof input === "string" ? input : input.toString(), init)) as typeof fetch;
+  try {
+    return await fn();
+  } finally {
+    globalThis.fetch = original;
+  }
+}
+
+function makeTmpDir(layout: Record<string, string>): string {
+  const dir = mkdtempSync(join(tmpdir(), "agent-pin-test-"));
+  for (const [relpath, content] of Object.entries(layout)) {
+    const full = join(dir, relpath);
+    mkdirSync(join(full, ".."), { recursive: true });
+    writeFileSync(full, content);
+  }
+  return dir;
+}
+
+const POLICY_JSON = JSON.stringify({
+  $schema: "https://json-schema.org/draft/2020-12/schema",
+  $id: "https://example.com/policies/p.json",
+  hello: "world",
+});
+
+function withEnv<T>(key: string, value: string | undefined, fn: () => Promise<T>): Promise<T> {
+  const prev = process.env[key];
+  if (value === undefined) delete process.env[key];
+  else process.env[key] = value;
+  return fn().finally(() => {
+    if (prev === undefined) delete process.env[key];
+    else process.env[key] = prev;
+  });
+}
+
+test("agentPin — happy path: pins a 2-file dir, returns ipfs URIs rooted at the CID", async () => {
+  const dir = makeTmpDir({
+    "README.md": "hi",
+    "policies/p.json": POLICY_JSON,
+  });
+  try {
+    const result = await withEnv("PINATA_JWT", "TEST_JWT", () =>
+      withMockedFetch(
+        (url) => {
+          if (url === "https://api.pinata.cloud/pinning/pinFileToIPFS") {
+            return new Response(JSON.stringify({ IpfsHash: FAKE_CID }), { status: 200 });
+          }
+          // verify probe
+          return new Response("ok", { status: 200 });
+        },
+        () => agentPin({ dir, format: "json" }),
+      ),
+    );
+    assert.equal(result.cid, FAKE_CID);
+    assert.equal(result.files.length, 2);
+    assert.ok(result.files.some((f) => f.relpath === "README.md"));
+    assert.ok(result.files.some((f) => f.relpath === "policies/p.json"));
+    assert.equal(result.verified, true);
+    assert.equal(result.policyHash, undefined);
+  } finally {
+    rmSync(dir, { recursive: true });
+  }
+});
+
+test("agentPin --policy <relpath> — computes policyHash via the resolver's JCS path", async () => {
+  const dir = makeTmpDir({
+    "README.md": "hi",
+    "policies/p.json": POLICY_JSON,
+  });
+  try {
+    const result = await withEnv("PINATA_JWT", "TEST_JWT", () =>
+      withMockedFetch(
+        (url) =>
+          url.includes("pinFileToIPFS")
+            ? new Response(JSON.stringify({ IpfsHash: FAKE_CID }), { status: 200 })
+            : new Response("ok", { status: 200 }),
+        () => agentPin({ dir, policy: "policies/p.json", format: "json" }),
+      ),
+    );
+    assert.match(result.policyHash ?? "", /^0x[0-9a-f]{64}$/);
+    assert.equal(result.policyRelpath, "policies/p.json");
+  } finally {
+    rmSync(dir, { recursive: true });
+  }
+});
+
+test("agentPin --policy <relpath-not-in-dir> — exits 2 before any Pinata call", async () => {
+  const dir = makeTmpDir({
+    "README.md": "hi",
+    "policies/p.json": POLICY_JSON,
+  });
+  try {
+    let pinataCalled = false;
+    await assert.rejects(
+      () =>
+        withEnv("PINATA_JWT", "TEST_JWT", () =>
+          withMockedFetch(
+            () => {
+              pinataCalled = true;
+              return new Response("{}", { status: 200 });
+            },
+            () => agentPin({ dir, policy: "does-not-exist.json", format: "json" }),
+          ),
+        ),
+      /not found inside/,
+    );
+    assert.equal(pinataCalled, false);
+    assert.equal(process.exitCode, 2);
+    process.exitCode = 0;
+  } finally {
+    rmSync(dir, { recursive: true });
+  }
+});
+
+test("agentPin without PINATA_JWT — exits 2 with a clear message", async () => {
+  const dir = makeTmpDir({ "a.json": "{}", "b.json": "{}" });
+  try {
+    await assert.rejects(
+      () =>
+        withEnv("PINATA_JWT", undefined, () => agentPin({ dir, format: "json" })),
+      /PINATA_JWT/,
+    );
+    assert.equal(process.exitCode, 2);
+    process.exitCode = 0;
+  } finally {
+    rmSync(dir, { recursive: true });
+  }
+});
+
+test("agentPin with single-file dir — exits 2 (Pinata flattens)", async () => {
+  const dir = makeTmpDir({ "only.json": "{}" });
+  try {
+    await assert.rejects(
+      () =>
+        withEnv("PINATA_JWT", "TEST_JWT", () =>
+          agentPin({ dir, format: "json" }),
+        ),
+      /at least 2 files/,
+    );
+    assert.equal(process.exitCode, 2);
+    process.exitCode = 0;
+  } finally {
+    rmSync(dir, { recursive: true });
+  }
+});
+
+test("agentPin --no-verify — skips the gateway probe, sets verified=true (probe-skipped semantics)", async () => {
+  const dir = makeTmpDir({ "a.json": "{}", "b.json": "{}" });
+  try {
+    let probeHit = false;
+    const result = await withEnv("PINATA_JWT", "TEST_JWT", () =>
+      withMockedFetch(
+        (url) => {
+          if (url.includes("pinFileToIPFS")) {
+            return new Response(JSON.stringify({ IpfsHash: FAKE_CID }), { status: 200 });
+          }
+          probeHit = true;
+          return new Response("ok", { status: 200 });
+        },
+        () => agentPin({ dir, noVerify: true, format: "json" }),
+      ),
+    );
+    assert.equal(probeHit, false);
+    assert.equal(result.verified, true);
+  } finally {
+    rmSync(dir, { recursive: true });
+  }
+});
+
+test("INTEGRATION pin → verify round-trip on a throwaway dir (gated on INTEGRATION_TESTS=1)", async () => {
+  // Round-trip the JCS + keccak path against real Pinata. Pin a tmpdir
+  // containing a small policy doc, then re-fetch from the resulting CID
+  // via fetchIpfsRaw and assert keccak256(JCS(fetched)) == policyHash
+  // returned by `agent pin`. A bug in either side surfaces here.
+  if (!process.env.INTEGRATION_TESTS || !process.env.PINATA_JWT) return;
+  const { fetchIpfsRaw, canonicalizeBytes } = await import("@synthesis/resolver");
+  const { keccak256, toHex } = await import("viem");
+
+  const dir = makeTmpDir({
+    "README.md": "integration-test pin",
+    "policies/p.json": POLICY_JSON,
+  });
+  try {
+    const result = await agentPin({
+      dir,
+      policy: "policies/p.json",
+      format: "json",
+    });
+    assert.match(result.policyHash ?? "", /^0x[0-9a-f]{64}$/);
+    // Pull the policy back from IPFS via the same gateway race the verifier
+    // uses, then recompute the hash from those bytes.
+    const fetched = await fetchIpfsRaw(`ipfs://${result.cid}/policies/p.json`);
+    const obj = JSON.parse(new TextDecoder().decode(fetched.bytes));
+    const recomputed = keccak256(toHex(canonicalizeBytes(obj)));
+    assert.equal(recomputed, result.policyHash);
+  } finally {
+    rmSync(dir, { recursive: true });
+  }
+});
+
+test("agentPin verify probe fails — exit code 1, error surfaces in JSON output", async () => {
+  const dir = makeTmpDir({ "a.json": "{}", "b.json": "{}" });
+  try {
+    await assert.rejects(
+      () =>
+        withEnv("PINATA_JWT", "TEST_JWT", () =>
+          withMockedFetch(
+            (url) =>
+              url.includes("pinFileToIPFS")
+                ? new Response(JSON.stringify({ IpfsHash: FAKE_CID }), { status: 200 })
+                : new Response("not found", { status: 404 }),
+            () => agentPin({ dir, format: "json" }),
+          ),
+        ),
+      /gateway probe failed/,
+    );
+    assert.equal(process.exitCode, 1);
+    process.exitCode = 0;
+  } finally {
+    rmSync(dir, { recursive: true });
+  }
+});

--- a/packages/cli/commands/agent-pin.ts
+++ b/packages/cli/commands/agent-pin.ts
@@ -13,7 +13,7 @@
  */
 
 import { readFileSync, readSync, statSync, readdirSync } from "node:fs";
-import { basename, join, relative } from "node:path";
+import { basename, join, relative, sep } from "node:path";
 import colors from "yoctocolors";
 import { keccak256, toHex } from "viem";
 import {
@@ -44,6 +44,11 @@ export interface PinResult extends PinDirectoryResult {
 /**
  * Walk `dir` and return all regular files as { relpath, bytes }. Skips
  * macOS metadata files (.DS_Store) — same exclusion the bash uses.
+ *
+ * Relpaths are always returned with POSIX `/` separators. `path.relative`
+ * returns native separators (backslashes on Windows), but Pinata filenames,
+ * `ipfs://<cid>/...` URLs, and `--policy <relpath>` matching all need
+ * forward slashes to be consistent across platforms.
  */
 function readDirRecursive(dir: string): PinDirectoryFile[] {
   const out: PinDirectoryFile[] = [];
@@ -54,7 +59,7 @@ function readDirRecursive(dir: string): PinDirectoryFile[] {
       if (entry.isDirectory()) {
         walk(full);
       } else if (entry.isFile()) {
-        const relpath = relative(dir, full);
+        const relpath = relative(dir, full).split(sep).join("/");
         out.push({ relpath, bytes: new Uint8Array(readFileSync(full)) });
       }
     }

--- a/packages/cli/commands/agent-pin.ts
+++ b/packages/cli/commands/agent-pin.ts
@@ -1,0 +1,257 @@
+/**
+ * `ensemble agent pin <dir>` — CLI presenter.
+ *
+ * Pins a directory of agent-identity files to Pinata via raw fetch
+ * (no @pinata/sdk dep). Optionally computes the policy-hash via the
+ * resolver's RFC 8785 JCS canonicalizer + viem keccak256 — same path
+ * the verifier (#46) uses to validate the on-chain `policy-hash` record,
+ * so pin/verify is a closed round-trip.
+ *
+ * No ENS writes. No mutation of operator config files. Output is
+ * structured (--format json) so callers can pipe into `jq` and decide
+ * where to put SCHEMA_URI / DELEGATION_URI / POLICY_HASH themselves.
+ */
+
+import { readFileSync, readSync, statSync, readdirSync } from "node:fs";
+import { basename, join, relative } from "node:path";
+import colors from "yoctocolors";
+import { keccak256, toHex } from "viem";
+import {
+  pinDirectory,
+  verifyPinResolves,
+  canonicalizeBytes,
+  type PinDirectoryFile,
+  type PinDirectoryResult,
+} from "@synthesis/resolver";
+import { startSpinner, stopSpinner } from "../utils/spinner";
+
+export interface AgentPinCliOptions {
+  dir: string;
+  policy?: string;
+  metadataName?: string;
+  gateway?: string;
+  noVerify?: boolean;
+  format?: string;
+  explain?: boolean;
+}
+
+export interface PinResult extends PinDirectoryResult {
+  policyHash?: string;
+  policyRelpath?: string;
+  verified: boolean;
+}
+
+/**
+ * Walk `dir` and return all regular files as { relpath, bytes }. Skips
+ * macOS metadata files (.DS_Store) — same exclusion the bash uses.
+ */
+function readDirRecursive(dir: string): PinDirectoryFile[] {
+  const out: PinDirectoryFile[] = [];
+  const walk = (sub: string) => {
+    for (const entry of readdirSync(sub, { withFileTypes: true })) {
+      const full = join(sub, entry.name);
+      if (entry.name === ".DS_Store") continue;
+      if (entry.isDirectory()) {
+        walk(full);
+      } else if (entry.isFile()) {
+        const relpath = relative(dir, full);
+        out.push({ relpath, bytes: new Uint8Array(readFileSync(full)) });
+      }
+    }
+  };
+  walk(dir);
+  return out;
+}
+
+function readStdinSync(): Uint8Array {
+  // Synchronous stdin read — required so the CLI can be used in pipelines
+  // (`cat policy.json | ensemble agent pin <dir> --policy -`) without
+  // restructuring the whole command around async stdin handling.
+  const chunks: Buffer[] = [];
+  const buf = Buffer.alloc(65536);
+  let bytesRead = 0;
+  // fd 0 = stdin
+  try {
+    while ((bytesRead = readSync(0, buf, 0, buf.length, null)) > 0) {
+      chunks.push(Buffer.from(buf.subarray(0, bytesRead)));
+    }
+  } catch (err) {
+    // EAGAIN can happen if stdin is a non-blocking TTY; treat as empty.
+    if ((err as NodeJS.ErrnoException).code !== "EAGAIN") throw err;
+  }
+  return new Uint8Array(Buffer.concat(chunks));
+}
+
+function isJsonFlag(): boolean {
+  return process.argv.some(
+    (arg, i, arr) =>
+      arg === "--format=json" ||
+      (arg === "--format" && arr[i + 1] === "json") ||
+      (arg === "-f" && arr[i + 1] === "json"),
+  );
+}
+
+export async function agentPin(options: AgentPinCliOptions): Promise<PinResult> {
+  const isJson = options.format === "json" || isJsonFlag();
+  const jwt = process.env.PINATA_JWT;
+  if (!jwt) {
+    const message = "PINATA_JWT env var is required for `agent pin`. Get a JWT at https://pinata.cloud and export PINATA_JWT=...";
+    if (isJson) console.log(JSON.stringify({ error: message }));
+    else console.error(colors.red(message));
+    process.exitCode = 2;
+    throw new Error(message);
+  }
+
+  // Validate dir exists.
+  let stat;
+  try {
+    stat = statSync(options.dir);
+  } catch (err) {
+    const message = `dir not found: ${options.dir} (${(err as Error).message})`;
+    if (isJson) console.log(JSON.stringify({ error: message }));
+    else console.error(colors.red(message));
+    process.exitCode = 2;
+    throw new Error(message);
+  }
+  if (!stat.isDirectory()) {
+    const message = `not a directory: ${options.dir}`;
+    if (isJson) console.log(JSON.stringify({ error: message }));
+    else console.error(colors.red(message));
+    process.exitCode = 2;
+    throw new Error(message);
+  }
+
+  const files = readDirRecursive(options.dir);
+  if (files.length < 2) {
+    const message = `directory must contain at least 2 files (Pinata flattens single-file directory pins). Found ${files.length} in ${options.dir}.`;
+    if (isJson) console.log(JSON.stringify({ error: message }));
+    else console.error(colors.red(message));
+    process.exitCode = 2;
+    throw new Error(message);
+  }
+
+  // If --policy is set, locate (or read from stdin) the policy bytes BEFORE
+  // calling Pinata so a missing-file error doesn't leave the operator with
+  // an orphan pin.
+  let policyBytes: Uint8Array | undefined;
+  let policyRelpath: string | undefined;
+  if (options.policy !== undefined) {
+    if (options.policy === "-") {
+      policyBytes = readStdinSync();
+      policyRelpath = "<stdin>";
+      if (policyBytes.length === 0) {
+        const message = "--policy - requires non-empty bytes on stdin";
+        if (isJson) console.log(JSON.stringify({ error: message }));
+        else console.error(colors.red(message));
+        process.exitCode = 2;
+        throw new Error(message);
+      }
+    } else {
+      // Look up the policy in the files we just read so the bytes match
+      // exactly what Pinata is about to receive — no chance of a TOCTOU
+      // mismatch where the file is rewritten between read and pin.
+      const f = files.find((x) => x.relpath === options.policy);
+      if (!f) {
+        const message = `--policy ${options.policy} not found inside ${options.dir} (relative paths only)`;
+        if (isJson) console.log(JSON.stringify({ error: message }));
+        else console.error(colors.red(message));
+        process.exitCode = 2;
+        throw new Error(message);
+      }
+      policyBytes = f.bytes;
+      policyRelpath = options.policy;
+    }
+  }
+
+  const metadataName = options.metadataName ?? basename(options.dir);
+
+  if (!isJson) {
+    startSpinner(`Pinning ${files.length} file(s) from ${colors.cyan(options.dir)} to Pinata...`);
+  }
+
+  let pinned: PinDirectoryResult;
+  try {
+    pinned = await pinDirectory(files, {
+      jwt,
+      metadataName,
+      gateway: options.gateway,
+    });
+  } catch (err) {
+    stopSpinner();
+    const message = (err as Error).message;
+    if (isJson) console.log(JSON.stringify({ error: message }));
+    else console.error(colors.red(message));
+    process.exitCode = 1;
+    throw err;
+  }
+
+  stopSpinner();
+
+  // Compute policy hash AFTER pin so a hash-only failure doesn't leave the
+  // operator without a CID. Hash is purely local — it can be recomputed
+  // any time, but the CID can't.
+  let policyHash: string | undefined;
+  if (policyBytes) {
+    const obj = JSON.parse(new TextDecoder().decode(policyBytes));
+    policyHash = keccak256(toHex(canonicalizeBytes(obj)));
+  }
+
+  // Post-pin gateway probe (default on). Surfaces transient pin failures
+  // before downstream `agent publish` writes a record pointing at unreachable
+  // bytes.
+  let verified = !!options.noVerify; // if --no-verify, treat as "skipped" but report verified=true
+  if (!options.noVerify) {
+    if (!isJson) {
+      startSpinner(`Probing ${pinned.files.length} files via gateway...`);
+    }
+    const fail = await verifyPinResolves(pinned);
+    stopSpinner();
+    if (fail) {
+      const message = `gateway probe failed: ${fail.relpath} → ${fail.reason}`;
+      if (isJson) {
+        console.log(JSON.stringify({ ...pinned, policyHash, policyRelpath, verified: false, error: message }, null, 2));
+      } else {
+        console.error(colors.red(`✗ ${message}`));
+      }
+      process.exitCode = 1;
+      throw new Error(message);
+    }
+    verified = true;
+  }
+
+  const result: PinResult = {
+    ...pinned,
+    policyHash,
+    policyRelpath,
+    verified,
+  };
+
+  if (isJson) {
+    console.log(JSON.stringify(result, null, 2));
+  } else {
+    console.log();
+    console.log(colors.bold("  Pin Result"));
+    console.log(colors.dim("  ──────────"));
+    console.log(`    CID            : ${colors.cyan(result.cid)}`);
+    console.log(`    Files          : ${result.files.length}`);
+    console.log(`    Metadata name  : ${metadataName}`);
+    console.log(`    Verified       : ${verified ? colors.green("yes") : colors.dim("skipped (--no-verify)")}`);
+    if (policyHash) {
+      console.log(`    Policy hash    : ${colors.green(policyHash)}`);
+      console.log(`    Policy file    : ${colors.dim(policyRelpath ?? "?")}`);
+    }
+    console.log();
+    if (options.explain) {
+      console.log(colors.bold("  IPFS URIs"));
+      console.log(colors.dim("  ─────────"));
+      for (const f of result.files) {
+        console.log(`    ${colors.dim(f.relpath)}`);
+        console.log(`      ${f.ipfsUri}`);
+      }
+      console.log();
+    }
+  }
+
+  process.exitCode = 0;
+  return result;
+}

--- a/packages/cli/commands/index.ts
+++ b/packages/cli/commands/index.ts
@@ -17,6 +17,7 @@ export { renew } from "./renew";
 export { transfer } from "./transfer";
 export { registerAgent, linkAgent, agentInfo } from "./agent";
 export { agentVerify } from "./agent-verify";
+export { agentPin } from "./agent-pin";
 export { personhoodCheck, personhoodRegister } from "./personhood";
 export { trust } from "./trust";
 export { gate } from "./gate";

--- a/packages/cli/index.ts
+++ b/packages/cli/index.ts
@@ -29,6 +29,7 @@ import {
 	linkAgent,
 	agentInfo,
 	agentVerify,
+	agentPin,
 	personhoodCheck,
 	personhoodRegister,
 	trust as trustCmd,
@@ -851,6 +852,70 @@ agent.command("verify", {
 			ipfsGateway: options.ipfsGateway,
 			rpc: options.rpc,
 			timeout: options.timeout,
+			format: options.format,
+			explain: options.explain,
+		});
+	},
+});
+
+agent.command("pin", {
+	description:
+		"Pin a directory of agent-identity files to Pinata. Optionally compute the policy-hash via JCS + keccak256 — same path the verifier uses, so pin/verify is a closed round-trip. Reads $PINATA_JWT.",
+	args: z.object({
+		dir: z.string().describe("Local directory to pin (every regular file is uploaded)"),
+	}),
+	options: z.object({
+		policy: z
+			.string()
+			.optional()
+			.describe(
+				"After pin, compute keccak256(JCS(file)) as `policyHash`. Value is a relpath inside <dir>, or `-` to read policy bytes from stdin.",
+			),
+		metadataName: z
+			.string()
+			.optional()
+			.describe("Pinata pinataMetadata.name. Default: basename(dir). Stable, not timestamped — Pinata pins are content-addressed and re-pinning is idempotent."),
+		gateway: z
+			.string()
+			.optional()
+			.describe("Gateway used for the post-pin verification probe (default: gateway.pinata.cloud)"),
+		noVerify: z
+			.boolean()
+			.optional()
+			.describe("Skip the post-pin gateway-resolution probe"),
+		format: z
+			.enum(["json"])
+			.optional()
+			.describe("Emit a structured PinResult on stdout instead of the human layout"),
+		explain: z
+			.boolean()
+			.optional()
+			.describe("Print all per-file IPFS URIs"),
+	}),
+	alias: { policy: "p", format: "f" },
+	examples: [
+		{
+			args: { dir: "./spec/ipfs" },
+			description: "Pin a spec directory",
+		},
+		{
+			args: { dir: "./spec/ipfs" },
+			options: { policy: "policies/delegation-policy-v1.json" },
+			description: "Pin and compute policy-hash",
+		},
+		{
+			args: { dir: "./spec/ipfs" },
+			options: { policy: "-", format: "json" },
+			description: "Pipe policy bytes via stdin and emit JSON for jq",
+		},
+	],
+	async run({ args, options }) {
+		return await agentPin({
+			dir: args.dir,
+			policy: options.policy,
+			metadataName: options.metadataName,
+			gateway: options.gateway,
+			noVerify: options.noVerify,
 			format: options.format,
 			explain: options.explain,
 		});

--- a/packages/resolver/src/index.ts
+++ b/packages/resolver/src/index.ts
@@ -70,6 +70,15 @@ export {
 export { canonicalize, canonicalizeBytes } from "./utils/jcs.js";
 
 export {
+  pinDirectory,
+  verifyPinResolves,
+  type PinDirectoryFile,
+  type PinDirectoryOptions,
+  type PinDirectoryResult,
+  type VerifyPinOptions,
+} from "./utils/pinata.js";
+
+export {
   createEnsClient,
   normalizeName,
   getTextRecord,
@@ -81,6 +90,7 @@ export {
 export {
   extractCid,
   fetchFromIpfs,
+  fetchIpfsRaw,
   fetchJsonFromIpfs,
   cidToUri,
   cidToGatewayUrl,

--- a/packages/resolver/src/utils/pinata.test.ts
+++ b/packages/resolver/src/utils/pinata.test.ts
@@ -1,0 +1,236 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { pinDirectory, verifyPinResolves } from "./pinata.js";
+
+const FAKE_CID = "bafybeicqnxyjsvro7ipmdhhzymtk5y2qbaudzmtgggllt7midikdxkmoxi";
+
+interface CapturedRequest {
+  url: string;
+  method: string | undefined;
+  headers: Record<string, string>;
+  formEntries: { name: string; value: unknown; filename?: string }[];
+}
+
+async function captureRequest(
+  responder: (req: CapturedRequest) => Response | Promise<Response>,
+): Promise<{ fetchMock: typeof fetch; captured: CapturedRequest[] }> {
+  const captured: CapturedRequest[] = [];
+  const fetchMock: typeof fetch = async (input: RequestInfo | URL, init) => {
+    const url = typeof input === "string" ? input : input.toString();
+    const headers: Record<string, string> = {};
+    if (init?.headers) {
+      const h = init.headers as Record<string, string>;
+      for (const k of Object.keys(h)) headers[k.toLowerCase()] = h[k];
+    }
+    const formEntries: CapturedRequest["formEntries"] = [];
+    if (init?.body instanceof FormData) {
+      for (const [name, value] of init.body.entries()) {
+        if (value instanceof File) {
+          formEntries.push({ name, value: await value.arrayBuffer(), filename: value.name });
+        } else {
+          formEntries.push({ name, value });
+        }
+      }
+    }
+    const req: CapturedRequest = { url, method: init?.method, headers, formEntries };
+    captured.push(req);
+    return responder(req);
+  };
+  return { fetchMock, captured };
+}
+
+test("pinDirectory POSTs multipart form to pinFileToIPFS with bearer auth", async () => {
+  const { fetchMock, captured } = await captureRequest(
+    () =>
+      new Response(JSON.stringify({ IpfsHash: FAKE_CID, PinSize: 1, Timestamp: "now" }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      }),
+  );
+  await pinDirectory(
+    [
+      { relpath: "README.md", bytes: new TextEncoder().encode("hi") },
+      { relpath: "schemas/agent-schema-v1.json", bytes: new TextEncoder().encode("{}") },
+    ],
+    { jwt: "JWT_TOKEN", fetch: fetchMock },
+  );
+  assert.equal(captured.length, 1);
+  assert.equal(captured[0].url, "https://api.pinata.cloud/pinning/pinFileToIPFS");
+  assert.equal(captured[0].method, "POST");
+  assert.equal(captured[0].headers.authorization, "Bearer JWT_TOKEN");
+});
+
+test("pinDirectory applies pin-root/ synthetic prefix to every file (Pinata directory-shape requirement)", async () => {
+  const { fetchMock, captured } = await captureRequest(
+    () => new Response(JSON.stringify({ IpfsHash: FAKE_CID }), { status: 200 }),
+  );
+  await pinDirectory(
+    [
+      { relpath: "README.md", bytes: new Uint8Array() },
+      { relpath: "schemas/agent-schema-v1.json", bytes: new Uint8Array() },
+      { relpath: "policies/delegation-policy-v1.json", bytes: new Uint8Array() },
+    ],
+    { jwt: "X", fetch: fetchMock },
+  );
+  const fileEntries = captured[0].formEntries.filter((e) => e.name === "file");
+  assert.equal(fileEntries.length, 3);
+  // Without the synthetic prefix, Pinata strips path components and
+  // collapses the upload to a flat list — these assertions detect that
+  // regression.
+  assert.equal(fileEntries[0].filename, "pin-root/README.md");
+  assert.equal(fileEntries[1].filename, "pin-root/schemas/agent-schema-v1.json");
+  assert.equal(fileEntries[2].filename, "pin-root/policies/delegation-policy-v1.json");
+});
+
+test("pinDirectory passes pinataOptions cidVersion=1 (modern bafy... CIDs)", async () => {
+  const { fetchMock, captured } = await captureRequest(
+    () => new Response(JSON.stringify({ IpfsHash: FAKE_CID }), { status: 200 }),
+  );
+  await pinDirectory(
+    [
+      { relpath: "a.json", bytes: new Uint8Array() },
+      { relpath: "b.json", bytes: new Uint8Array() },
+    ],
+    { jwt: "X", fetch: fetchMock },
+  );
+  const opts = captured[0].formEntries.find((e) => e.name === "pinataOptions");
+  assert.ok(opts);
+  assert.deepEqual(JSON.parse(opts.value as string), { cidVersion: 1 });
+});
+
+test("pinDirectory uses caller's metadataName (no timestamp surprise)", async () => {
+  const { fetchMock, captured } = await captureRequest(
+    () => new Response(JSON.stringify({ IpfsHash: FAKE_CID }), { status: 200 }),
+  );
+  await pinDirectory(
+    [
+      { relpath: "a.json", bytes: new Uint8Array() },
+      { relpath: "b.json", bytes: new Uint8Array() },
+    ],
+    { jwt: "X", metadataName: "agent-policy-v1", fetch: fetchMock },
+  );
+  const meta = captured[0].formEntries.find((e) => e.name === "pinataMetadata");
+  assert.deepEqual(JSON.parse(meta!.value as string), { name: "agent-policy-v1" });
+});
+
+test("pinDirectory returns ipfs:// + gateway URLs rooted at the returned CID", async () => {
+  const { fetchMock } = await captureRequest(
+    () => new Response(JSON.stringify({ IpfsHash: FAKE_CID }), { status: 200 }),
+  );
+  const result = await pinDirectory(
+    [
+      { relpath: "schemas/agent-schema-v1.json", bytes: new Uint8Array() },
+      { relpath: "policies/delegation-policy-v1.json", bytes: new Uint8Array() },
+    ],
+    { jwt: "X", fetch: fetchMock },
+  );
+  assert.equal(result.cid, FAKE_CID);
+  assert.equal(
+    result.files[0].ipfsUri,
+    `ipfs://${FAKE_CID}/schemas/agent-schema-v1.json`,
+  );
+  assert.equal(
+    result.files[0].gatewayUrl,
+    `https://gateway.pinata.cloud/ipfs/${FAKE_CID}/schemas/agent-schema-v1.json`,
+  );
+});
+
+test("pinDirectory honors a custom gateway for the returned URLs", async () => {
+  const { fetchMock } = await captureRequest(
+    () => new Response(JSON.stringify({ IpfsHash: FAKE_CID }), { status: 200 }),
+  );
+  const result = await pinDirectory(
+    [
+      { relpath: "a.json", bytes: new Uint8Array() },
+      { relpath: "b.json", bytes: new Uint8Array() },
+    ],
+    { jwt: "X", gateway: "my-gw.pinata.cloud", fetch: fetchMock },
+  );
+  assert.ok(result.files[0].gatewayUrl.startsWith("https://my-gw.pinata.cloud/ipfs/"));
+});
+
+test("pinDirectory throws on Pinata 4xx with status + body excerpt", async () => {
+  const { fetchMock } = await captureRequest(
+    () =>
+      new Response(JSON.stringify({ error: "invalid auth" }), {
+        status: 401,
+        headers: { "content-type": "application/json" },
+      }),
+  );
+  await assert.rejects(
+    () =>
+      pinDirectory(
+        [
+          { relpath: "a.json", bytes: new Uint8Array() },
+          { relpath: "b.json", bytes: new Uint8Array() },
+        ],
+        { jwt: "BAD", fetch: fetchMock },
+      ),
+    /HTTP 401/,
+  );
+});
+
+test("pinDirectory throws when response lacks IpfsHash", async () => {
+  const { fetchMock } = await captureRequest(
+    () => new Response(JSON.stringify({ unexpected: true }), { status: 200 }),
+  );
+  await assert.rejects(
+    () =>
+      pinDirectory(
+        [
+          { relpath: "a.json", bytes: new Uint8Array() },
+          { relpath: "b.json", bytes: new Uint8Array() },
+        ],
+        { jwt: "X", fetch: fetchMock },
+      ),
+    /missing IpfsHash/,
+  );
+});
+
+test("pinDirectory rejects 0-file and 1-file pins (Pinata flattens single-file directories)", async () => {
+  await assert.rejects(
+    () => pinDirectory([], { jwt: "X" }),
+    /at least one file/,
+  );
+  await assert.rejects(
+    () => pinDirectory([{ relpath: "a.json", bytes: new Uint8Array() }], { jwt: "X" }),
+    /at least 2 files/,
+  );
+});
+
+test("verifyPinResolves returns null on full success", async () => {
+  const fetchMock: typeof fetch = async () => new Response("{}", { status: 200 });
+  const result = {
+    cid: FAKE_CID,
+    files: [
+      {
+        relpath: "a.json",
+        ipfsUri: `ipfs://${FAKE_CID}/a.json`,
+        gatewayUrl: `https://gateway.pinata.cloud/ipfs/${FAKE_CID}/a.json`,
+      },
+      {
+        relpath: "b.json",
+        ipfsUri: `ipfs://${FAKE_CID}/b.json`,
+        gatewayUrl: `https://gateway.pinata.cloud/ipfs/${FAKE_CID}/b.json`,
+      },
+    ],
+  };
+  assert.equal(await verifyPinResolves(result, { fetch: fetchMock }), null);
+});
+
+test("verifyPinResolves returns the first failing file on non-2xx", async () => {
+  const fetchMock: typeof fetch = async (input) => {
+    const url = typeof input === "string" ? input : input.toString();
+    if (url.endsWith("a.json")) return new Response("ok", { status: 200 });
+    return new Response("not found", { status: 404 });
+  };
+  const result = {
+    cid: FAKE_CID,
+    files: [
+      { relpath: "a.json", ipfsUri: "x", gatewayUrl: "https://gateway/a.json" },
+      { relpath: "b.json", ipfsUri: "x", gatewayUrl: "https://gateway/b.json" },
+    ],
+  };
+  const fail = await verifyPinResolves(result, { fetch: fetchMock });
+  assert.deepEqual(fail, { relpath: "b.json", reason: "HTTP 404" });
+});

--- a/packages/resolver/src/utils/pinata.test.ts
+++ b/packages/resolver/src/utils/pinata.test.ts
@@ -24,7 +24,11 @@ async function captureRequest(
     }
     const formEntries: CapturedRequest["formEntries"] = [];
     if (init?.body instanceof FormData) {
-      for (const [name, value] of init.body.entries()) {
+      // FormData iteration: the standard exposes [Symbol.iterator] yielding
+      // [name, value] tuples but lib.dom.d.ts in some TS targets omits
+      // .entries(). Cast through the iterable shape to stay portable.
+      const iterable = init.body as unknown as Iterable<[string, FormDataEntryValue]>;
+      for (const [name, value] of iterable) {
         if (value instanceof File) {
           formEntries.push({ name, value: await value.arrayBuffer(), filename: value.name });
         } else {

--- a/packages/resolver/src/utils/pinata.ts
+++ b/packages/resolver/src/utils/pinata.ts
@@ -1,0 +1,154 @@
+/**
+ * Pinata IPFS pinning — directory uploads via `pinFileToIPFS`.
+ *
+ * Why raw fetch instead of `@pinata/sdk`: one endpoint, one POST, ~80 lines.
+ * Pulling a top-level dep for that is a dep tax we'd carry into every
+ * downstream package that imports `@synthesis/resolver`. The bash scripts
+ * this code ports from also use raw curl; staying close to that surface
+ * makes mismatches easier to diagnose.
+ *
+ * Read-only on ENS — never writes records.
+ */
+
+const PIN_ENDPOINT = "https://api.pinata.cloud/pinning/pinFileToIPFS";
+const DEFAULT_GATEWAY = "gateway.pinata.cloud";
+
+/**
+ * Pinata's `pinFileToIPFS` only preserves directory structure when every
+ * uploaded file shares a common parent prefix. The bash invents a fake
+ * `pin-root/` prefix and prepends it to every form-field filename;
+ * Pinata strips the shared prefix and roots the resulting CID at the tree
+ * below. Replicate exactly — without it, multi-file uploads collapse to
+ * a flat list and `ipfs://<cid>/schemas/...` paths stop resolving.
+ */
+const PIN_ROOT = "pin-root";
+
+export interface PinDirectoryFile {
+  /** Path within the pinned directory (e.g. `schemas/agent-schema-v1.json`). */
+  relpath: string;
+  bytes: Uint8Array;
+}
+
+export interface PinDirectoryOptions {
+  /** Pinata API JWT. Required. Matches the `PINATA_JWT` env var name. */
+  jwt: string;
+  /** Pinata `pinataMetadata.name`. Defaults to a stable string the caller picks. */
+  metadataName?: string;
+  /** Gateway used to construct returned `gatewayUrl`s. Default: gateway.pinata.cloud. */
+  gateway?: string;
+  /** Inject for tests. Default: globalThis.fetch. */
+  fetch?: typeof fetch;
+}
+
+export interface PinDirectoryResult {
+  cid: string;
+  files: { relpath: string; ipfsUri: string; gatewayUrl: string }[];
+}
+
+/**
+ * Pin a set of files to Pinata as a single directory. Returns the
+ * directory CID and per-file `ipfs://` and gateway URLs rooted at it.
+ *
+ * Throws if Pinata returns a non-2xx response or omits `IpfsHash` from
+ * the JSON body. Network errors propagate — callers can wrap or retry.
+ */
+export async function pinDirectory(
+  files: PinDirectoryFile[],
+  options: PinDirectoryOptions,
+): Promise<PinDirectoryResult> {
+  if (files.length === 0) {
+    throw new Error("pinDirectory: at least one file is required");
+  }
+  if (files.length === 1) {
+    // Pinata flattens single-file pins regardless of the synthetic root.
+    // The bash warns about this; we reject it outright so the caller
+    // either adds a sentinel file (e.g. README.md) or uses a different
+    // single-file API.
+    throw new Error(
+      "pinDirectory: at least 2 files are required (Pinata flattens single-file directory pins). Add a sentinel file to preserve the tree.",
+    );
+  }
+  const fetchImpl = options.fetch ?? globalThis.fetch.bind(globalThis);
+  const gateway = options.gateway ?? DEFAULT_GATEWAY;
+
+  const form = new FormData();
+  for (const f of files) {
+    // FormData accepts a Blob; preserves binary bytes exactly.
+    // Cast through BlobPart — TS lib types reject Uint8Array<ArrayBufferLike>
+    // for Blob() in some lib targets even though it's the canonical input.
+    const blob = new Blob([f.bytes as BlobPart]);
+    form.append("file", blob, `${PIN_ROOT}/${f.relpath}`);
+  }
+  form.append(
+    "pinataMetadata",
+    JSON.stringify({ name: options.metadataName ?? "synthesis-agent-pin" }),
+  );
+  form.append("pinataOptions", JSON.stringify({ cidVersion: 1 }));
+
+  const response = await fetchImpl(PIN_ENDPOINT, {
+    method: "POST",
+    headers: { authorization: `Bearer ${options.jwt}` },
+    body: form,
+  });
+
+  if (!response.ok) {
+    let detail = "";
+    try {
+      detail = await response.text();
+    } catch {
+      // ignore
+    }
+    throw new Error(`Pinata pin failed: HTTP ${response.status}${detail ? ` — ${detail.slice(0, 200)}` : ""}`);
+  }
+
+  const body = (await response.json()) as { IpfsHash?: string };
+  const cid = body.IpfsHash;
+  if (!cid) {
+    throw new Error(`Pinata pin failed: response missing IpfsHash (got: ${JSON.stringify(body).slice(0, 200)})`);
+  }
+
+  return {
+    cid,
+    files: files.map((f) => ({
+      relpath: f.relpath,
+      ipfsUri: `ipfs://${cid}/${f.relpath}`,
+      gatewayUrl: `https://${gateway}/ipfs/${cid}/${f.relpath}`,
+    })),
+  };
+}
+
+export interface VerifyPinOptions {
+  timeoutMs?: number;
+  fetch?: typeof fetch;
+}
+
+/**
+ * Probe each pinned file's gateway URL to confirm Pinata has propagated
+ * the directory. Returns the first failure (file + reason) or null on
+ * full success. The bash scripts call out a transient-pin-failure mode
+ * where the CID is returned but content isn't immediately readable —
+ * this surfaces it before the operator publishes a record pointing at
+ * dead bytes.
+ */
+export async function verifyPinResolves(
+  result: PinDirectoryResult,
+  options: VerifyPinOptions = {},
+): Promise<{ relpath: string; reason: string } | null> {
+  const fetchImpl = options.fetch ?? globalThis.fetch.bind(globalThis);
+  const timeoutMs = options.timeoutMs ?? 30_000;
+  for (const f of result.files) {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), timeoutMs);
+    try {
+      const res = await fetchImpl(f.gatewayUrl, { signal: controller.signal });
+      if (!res.ok) {
+        return { relpath: f.relpath, reason: `HTTP ${res.status}` };
+      }
+    } catch (err) {
+      return { relpath: f.relpath, reason: (err as Error).message };
+    } finally {
+      clearTimeout(timer);
+    }
+  }
+  return null;
+}

--- a/plans/ensemble-agent-pin.md
+++ b/plans/ensemble-agent-pin.md
@@ -1,0 +1,77 @@
+# Plan: `ensemble agent pin <dir>`
+
+PR #4 of the §7 roadmap. Ports `pin-schema.sh` + `pin-policy.sh` (in
+`agency/deploy/ens-agent/scripts/`) into a single CLI command. After
+this lands, the deploy path is reachable from the synthesis CLI without
+the agency-repo bash scripts.
+
+## Scope
+
+### In
+
+- New CLI subcommand `ensemble agent pin <dir>`
+- Library function `pinDirectory(files, options)` exported from `@synthesis/resolver`
+- Multipart upload to Pinata's `pinFileToIPFS`
+- `pin-root/` synthetic prefix replicated (Pinata directory-shape requirement)
+- `--policy <relpath>` computes `keccak256(JCS(file))` via the resolver's
+  existing canonicalizer — same path the verifier uses
+- `--policy -` reads policy bytes from stdin (CI without temp files)
+- Post-pin gateway-resolution probe (default on)
+- Human + `--format json` output
+
+### Out (separate PRs)
+
+- ENS record writes (`ensemble agent publish` — PR #5)
+- Key generation / kernel issuance (`ensemble agent issue` — PR #3)
+- Session-key rotation (`ensemble agent rotate` — PR #6)
+- Site explorer route (#44)
+
+## CLI surface
+
+```
+ensemble agent pin <dir>
+ensemble agent pin <dir> --policy policies/delegation-policy-v1.json
+cat policy.json | ensemble agent pin <dir> --policy -
+ensemble agent pin <dir> --metadata-name agent-policy-v1
+ensemble agent pin <dir> --gateway my-gw.pinata.cloud
+ensemble agent pin <dir> --no-verify --format json
+```
+
+| Flag | Default | Meaning |
+|---|---|---|
+| `--policy <relpath \| ->` | — | Compute `policyHash` from this file (relpath in `<dir>` or `-` for stdin) |
+| `--metadata-name` | `basename(dir)` | Pinata `pinataMetadata.name`. Stable, not timestamped |
+| `--gateway` | `gateway.pinata.cloud` | Used only for the post-pin verification probe |
+| `--no-verify` | off | Skip the gateway probe |
+| `--format json` | — | Emit `PinResult` JSON |
+| `--explain` | off | Print all per-file IPFS URIs |
+
+Env: `PINATA_JWT` (required; same name as the agency scripts).
+
+Exit codes: 0 success, 1 pin / verify failure, 2 input error.
+
+## Decisions locked in advance
+
+- **Raw fetch, no `@pinata/sdk`.** One endpoint, one POST. Adding a top-level dep for that is a dep tax we'd carry through every `@synthesis/resolver` consumer. The bash scripts use raw curl.
+- **`--policy -` reads stdin.** Works in CI without temp files.
+- **`--metadata-name` defaults to a stable string (`basename(dir)`)** — matches the bash. Re-pinning is idempotent on Pinata's side; a timestamped default would clutter the operator's pin list.
+- **`pin-root/` synthetic prefix is replicated.** Without it Pinata flattens the directory.
+- **No `.env.deploy` mutation.** That's the bash script's job.
+- **Post-pin gateway probe defaults on.** Surfaces transient pin failures immediately.
+- **Single-file directory pins are rejected.** Pinata flattens them regardless of the synthetic root.
+
+## Round-trip integration test
+
+```bash
+INTEGRATION_TESTS=1 PINATA_JWT=... pnpm -r test
+```
+
+Pins a throwaway directory, re-fetches the policy via the resolver's gateway race, and asserts `keccak256(JCS(fetched-bytes)) === policyHash` returned by `agent pin`. Closes the loop between pin and verify.
+
+## Acceptance
+
+```bash
+pnpm install && pnpm -r build && pnpm -r test
+PINATA_JWT=... node packages/cli/dist/index.js agent pin /Users/oakgroup/webdev/agency/deploy/ens-agent/spec/ipfs --policy policies/delegation-policy-v1.json --format json
+# expects policyHash == 0x6f3878cb630f8d16e5f8eac858f8923d15d5475773c1205b97dab0b06b35c114
+```


### PR DESCRIPTION
## Summary

- New CLI subcommand `ensemble agent pin <dir>` and library function `pinDirectory` exported from `@synthesis/resolver`. Ports `pin-schema.sh` + `pin-policy.sh` from the agency repo into a single CLI command. After this, the deploy path is reachable from the synthesis CLI without the bash scripts.
- Closed pin/verify round-trip: live `agent pin` of the agency repo's `spec/ipfs/` tree produces `policyHash = 0x6f3878cb630f8d16e5f8eac858f8923d15d5475773c1205b97dab0b06b35c114` — matches the on-chain `policy-hash` text record on `emilemarcelagustin.eth` byte-for-byte.
- 11 resolver pinata-utility tests + 7 CLI tests + 1 gated integration test. 59 + 15 total green offline.

Closes #48.

## Three amendments locked before coding

1. **Raw fetch, no `@pinata/sdk`.** One endpoint, one POST, ~80 lines. Adding a top-level dep for that is a tax we'd carry through every `@synthesis/resolver` consumer. The agency bash uses raw curl; staying close to that surface keeps mismatches diagnosable.
2. **`--policy -` reads stdin.** Lets `cat policy.json | ensemble agent pin <dir> --policy -` work in CI without temp files. Synchronous stdin read so the rest of the command stays straightforward.
3. **`--metadata-name` defaults to `basename(dir)`, stable not timestamped.** Matches the bash (`emilemarcelagustin-agent-schemas-v1`, `emilemarcelagustin-policy-v1` are stable). Pinata pins are content-addressed and re-pinning the same content is idempotent — a timestamped default would clutter the operator's pin list.

## Notable porting details (preserved from bash)

- **`pin-root/` synthetic prefix.** Pinata's `pinFileToIPFS` only preserves directory structure when uploaded files share a common parent prefix. The bash invents a `pin-root/` and prepends it to every form-field filename; we do the same. Without this, multi-file uploads collapse to a flat list and `ipfs://<cid>/schemas/...` paths stop resolving. Tested explicitly by `pinata.test.ts:36`.
- **`cidVersion: 1`.** Modern `bafy...` CIDs.
- **Post-pin gateway probe defaults on.** Surfaces transient pin failures immediately rather than at `agent verify` time.
- **Single-file directory pins are rejected** with a clear error. Pinata flattens them regardless of the synthetic root.

## Notable porting details (intentionally NOT preserved from bash)

- **No `.env.deploy` mutation.** The bash sed-replaces `SCHEMA_URI`/`DELEGATION_URI`/`POLICY_HASH`/`POLICY_VERSION` in operator config. The CLI prints structured output (`--format json`) and lets the operator pipe into `jq` and decide where to put the values.

## CLI surface

```
ensemble agent pin <dir>                                                # plain pin
ensemble agent pin <dir> --policy policies/delegation-policy-v1.json     # + policy hash
cat policy.json | ensemble agent pin <dir> --policy -                    # stdin
ensemble agent pin <dir> --metadata-name agent-policy-v1
ensemble agent pin <dir> --gateway my-gw.pinata.cloud
ensemble agent pin <dir> --no-verify --format json
```

| Flag | Default | Meaning |
|---|---|---|
| `--policy <relpath \| ->` | — | Compute `policyHash` from this file (relpath in `<dir>` or `-` for stdin) |
| `--metadata-name` | `basename(dir)` | Pinata `pinataMetadata.name`. Stable, not timestamped |
| `--gateway` | `gateway.pinata.cloud` | Used only for the post-pin verification probe |
| `--no-verify` | off | Skip the gateway probe |
| `--format json` | — | Emit structured `PinResult` JSON |

Env: `PINATA_JWT` (required, matches the agency scripts).

Exit codes: 0 success, 1 pin / verify failure, 2 input error.

## Library function

```ts
import { pinDirectory } from "@synthesis/resolver";

await pinDirectory(
  [
    { relpath: "schemas/agent-schema-v1.json", bytes: ... },
    { relpath: "policies/delegation-policy-v1.json", bytes: ... },
  ],
  { jwt: process.env.PINATA_JWT!, metadataName: "agent-v1" },
);
// → { cid: "bafy...", files: [{ relpath, ipfsUri, gatewayUrl }, ...] }
```

Reusable from PR #5 (`agent publish`) without duplicating Pinata code.

## Live round-trip

```bash
PINATA_JWT=... node packages/cli/dist/index.js agent pin \
  /Users/oakgroup/webdev/agency/deploy/ens-agent/spec/ipfs \
  --policy policies/delegation-policy-v1.json --format json | jq -r '.policyHash'
# 0x6f3878cb630f8d16e5f8eac858f8923d15d5475773c1205b97dab0b06b35c114
```

That hash matches the on-chain `policy-hash` text record on `emilemarcelagustin.eth` exactly — same value PR #46's verifier asserts against.

## Files

| File | Status |
|---|---|
| `packages/resolver/src/utils/pinata.ts` | new — `pinDirectory` + `verifyPinResolves` |
| `packages/resolver/src/utils/pinata.test.ts` | new — 11 unit tests |
| `packages/resolver/src/index.ts` | edit — re-export |
| `packages/cli/commands/agent-pin.ts` | new — CLI presenter, stdin support |
| `packages/cli/commands/agent-pin.test.ts` | new — 7 unit tests + 1 gated integration |
| `packages/cli/commands/index.ts`, `packages/cli/index.ts` | edit — wire `agent pin` |
| `plans/ensemble-agent-pin.md` | new — short plan |

## Test plan

- [x] `pnpm -r test` — 59 resolver + 15 CLI offline tests pass
- [x] `pnpm -r build` — clean
- [x] `pnpm typecheck` — clean
- [x] Live: `agent pin` of agency `spec/ipfs/` — `policyHash` matches on-chain `0x6f3878cb…`
- [x] Live: `--policy -` (stdin) — same hash
- [x] Live: re-pin produces same CID (Pinata idempotency, validates `metadataName` default choice)
- [ ] (gated `INTEGRATION_TESTS=1`) round-trip pin → fetch → re-hash matches `policyHash`

🤖 Generated with [Claude Code](https://claude.com/claude-code)