### PR TITLE
feat(cli,resolver): ensemble agent rotate <alias> --ens <ens-name> (closes #54)

### DIFF
--- a/packages/cli/commands/agent-rotate.test.ts
+++ b/packages/cli/commands/agent-rotate.test.ts
@@ -97,6 +97,24 @@ test("agent-rotate schema — uses ENS_PRIVATE_KEY (NOT a forked env-var name, C
   );
 });
 
+test("agent-rotate.ts — receipt polling uses the mainnet RPC, NOT --rpc (Codex P1)", () => {
+  // Source-level fence. The receipt-polling client must construct from
+  // config!.rpcUrl (mainnet ENS RPC) — not from options.rpc which is
+  // the Base smart-account RPC. Mismatched chainId+RPC silently polls
+  // the wrong chain after a successful publish.
+  const cli = readFileSync(join(__dirname, "agent-rotate.ts"), "utf8");
+  // Find the createChainPublicClient call in the receipt-poll branch
+  // (under "Waiting for confirmations").
+  const pollSection = cli.slice(cli.indexOf("Waiting for confirmations"));
+  // The call must NOT include `options.rpc` as the second argument.
+  assert.ok(
+    !/createChainPublicClient\([^)]*options\.rpc/s.test(pollSection),
+    "receipt poll must not pass options.rpc — pass config.rpcUrl (mainnet) only",
+  );
+  // It must reference config.rpcUrl directly.
+  assert.match(pollSection, /createChainPublicClient\(config!\.chainId,\s*config!\.rpcUrl/);
+});
+
 test("RotateResult shape — newSessionKeyArtifact is the named field, not newAlias (Codex amendment 1)", () => {
   // The amendment renamed `newAlias` → `newSessionKeyArtifact`. A
   // regression fence ensures the resolver export stays renamed and the

--- a/packages/cli/commands/agent-rotate.test.ts
+++ b/packages/cli/commands/agent-rotate.test.ts
@@ -1,0 +1,106 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { agentRotate } from "./agent-rotate";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+function withEnv<T>(
+  vars: Record<string, string | undefined>,
+  fn: () => Promise<T>,
+): Promise<T> {
+  const prev: Record<string, string | undefined> = {};
+  for (const k of Object.keys(vars)) {
+    prev[k] = process.env[k];
+    if (vars[k] === undefined) delete process.env[k];
+    else process.env[k] = vars[k]!;
+  }
+  return fn().finally(() => {
+    for (const k of Object.keys(prev)) {
+      if (prev[k] === undefined) delete process.env[k];
+      else process.env[k] = prev[k]!;
+    }
+  });
+}
+
+test("agentRotate — missing SYNTHESIS_KEYSTORE_PASSWORD exits 2", async () => {
+  await assert.rejects(
+    () =>
+      withEnv(
+        { SYNTHESIS_KEYSTORE_PASSWORD: undefined, PINATA_JWT: "fake" },
+        () => agentRotate({ alias: "x", ens: "x.eth", format: "json" }),
+      ),
+    /SYNTHESIS_KEYSTORE_PASSWORD/,
+  );
+  assert.equal(process.exitCode, 2);
+  process.exitCode = 0;
+});
+
+test("agentRotate — missing PINATA_JWT exits 2", async () => {
+  await assert.rejects(
+    () =>
+      withEnv(
+        { SYNTHESIS_KEYSTORE_PASSWORD: "p", PINATA_JWT: undefined },
+        () => agentRotate({ alias: "x", ens: "x.eth", format: "json" }),
+      ),
+    /PINATA_JWT/,
+  );
+  assert.equal(process.exitCode, 2);
+  process.exitCode = 0;
+});
+
+test("agentRotate — missing keystore at the alias path exits 2 with a clear message", async () => {
+  await assert.rejects(
+    () =>
+      withEnv(
+        { SYNTHESIS_KEYSTORE_PASSWORD: "p", PINATA_JWT: "fake" },
+        () =>
+          agentRotate({
+            alias: "this-alias-does-not-exist-anywhere-12345",
+            ens: "x.eth",
+            format: "json",
+          }),
+      ),
+    /agent issue this-alias-does-not-exist-anywhere-12345/,
+  );
+  assert.equal(process.exitCode, 2);
+  process.exitCode = 0;
+});
+
+test("agent-rotate schema — broadcast is the only opt-in (no --dry-run flag, regression fence from #51)", () => {
+  // Same lock as agent publish: --broadcast is the only mutation
+  // toggle. A future addition of --dry-run would conflict with that
+  // convention and is fenced off here.
+  const idx = readFileSync(join(__dirname, "..", "index.ts"), "utf8");
+  const start = idx.indexOf('agent.command("rotate"');
+  assert.ok(start >= 0, "agent rotate command must be registered");
+  const end = idx.indexOf("cli.command(agent)", start);
+  const slice = idx.slice(start, end);
+  assert.ok(/broadcast: z/.test(slice), "rotate must declare a broadcast option");
+  assert.ok(!/dryRun: z|"--dry-run"/.test(slice), "rotate must NOT declare a dryRun option");
+});
+
+test("agent-rotate schema — uses ENS_PRIVATE_KEY (NOT a forked env-var name, Codex amendment 2)", () => {
+  // Wallet-security memory locks the project signer to the manager EOA
+  // for emilemarcelagustin.eth. agent publish uses ENS_PRIVATE_KEY;
+  // agent rotate must use the same name. Test that the source file
+  // doesn't mention any other env-var pattern for the signer.
+  const cli = readFileSync(join(__dirname, "agent-rotate.ts"), "utf8");
+  // Must reference ENS_PRIVATE_KEY via getSignerAddress (which reads it),
+  // and must NOT introduce a forked name.
+  assert.ok(/ENS_PRIVATE_KEY/.test(cli), "agent-rotate.ts must reference ENS_PRIVATE_KEY");
+  assert.ok(
+    !/OWNER_PRIVATE_KEY|SIGNER_PRIVATE_KEY|ROTATE_PRIVATE_KEY/.test(cli),
+    "agent-rotate.ts must NOT introduce a forked private-key env name",
+  );
+});
+
+test("RotateResult shape — newSessionKeyArtifact is the named field, not newAlias (Codex amendment 1)", () => {
+  // The amendment renamed `newAlias` → `newSessionKeyArtifact`. A
+  // regression fence ensures the resolver export stays renamed and the
+  // CLI presenter doesn't accidentally reintroduce `newAlias`.
+  const cli = readFileSync(join(__dirname, "agent-rotate.ts"), "utf8");
+  assert.ok(/newSessionKeyArtifact/.test(cli), "presenter must reference newSessionKeyArtifact");
+});

--- a/packages/cli/commands/agent-rotate.ts
+++ b/packages/cli/commands/agent-rotate.ts
@@ -1,0 +1,288 @@
+/**
+ * `ensemble agent rotate <alias> --ens <ens-name>` — CLI presenter.
+ *
+ * Rotates the active session key + bumps policy version. Plan-only by
+ * default; --broadcast sends the multicall (matches the publish
+ * convention from #51). The wallet-security memory note for this repo
+ * locks the signing identity to the manager-of-emilemarcelagustin.eth
+ * EOA `0xeb0A…022`, supplied via $ENS_PRIVATE_KEY (or --ledger). Same
+ * env-var name as `agent publish`.
+ *
+ * Issues a new session-key under `<alias>-policy-v<N>` (where N is the
+ * NEW on-chain version), so the filesystem layout mirrors what's
+ * published. Old session-key files stay for audit; clean up via
+ * `rm` if desired.
+ */
+
+import { readFileSync } from "node:fs";
+import colors from "yoctocolors";
+import * as chains from "viem/chains";
+import {
+  rotateAgent,
+  type KeystoreJson,
+  type RotateResult,
+} from "@synthesis/resolver";
+import {
+  normalizeEnsName,
+  getResolver,
+  getNetworkConfig,
+  getSignerAddress,
+  getSignerAddressAsync,
+  closeLedger,
+} from "../utils";
+import { createChainPublicClient, createChainWalletClient } from "../utils/viem";
+import { startSpinner, stopSpinner } from "../utils/spinner";
+
+export interface AgentRotateCliOptions {
+  alias: string;
+  ens: string;
+  policyVersion?: string;
+  ttlHours?: string;
+  gasCapWei?: string;
+  chain?: string;
+  rpc?: string;
+  bundler?: string;
+  ipfsGateway?: string[];
+  broadcast?: boolean;
+  ledger?: boolean;
+  accountIndex?: string;
+  format?: string;
+}
+
+const KEYSTORE_PWD_ENV = "SYNTHESIS_KEYSTORE_PASSWORD";
+
+function isJsonFlag(): boolean {
+  return process.argv.some(
+    (arg, i, arr) =>
+      arg === "--format=json" ||
+      (arg === "--format" && arr[i + 1] === "json") ||
+      (arg === "-f" && arr[i + 1] === "json"),
+  );
+}
+
+function fail(isJson: boolean, code: 1 | 2, message: string): never {
+  if (isJson) console.log(JSON.stringify({ error: message }));
+  else console.error(colors.red(message));
+  process.exitCode = code;
+  throw new Error(message);
+}
+
+function resolveChain(label: string): { chain: import("viem").Chain; defaultRpc: string; defaultBundler: string } {
+  switch (label) {
+    case "base":
+      return {
+        chain: chains.base,
+        defaultRpc: "https://mainnet.base.org",
+        defaultBundler: "https://public.pimlico.io/v2/8453/rpc",
+      };
+    case "base-sepolia":
+      return {
+        chain: chains.baseSepolia,
+        defaultRpc: "https://sepolia.base.org",
+        defaultBundler: "https://public.pimlico.io/v2/84532/rpc",
+      };
+    default:
+      throw new Error(`unsupported --chain ${label} (supported: base, base-sepolia)`);
+  }
+}
+
+export async function agentRotate(options: AgentRotateCliOptions): Promise<RotateResult> {
+  const isJson = options.format === "json" || isJsonFlag();
+  const accountIndex = options.accountIndex ? parseInt(options.accountIndex, 10) : 0;
+
+  // Env: keystore password is always required (decrypts owner key for
+  // the new session-key issuance step). ENS_PRIVATE_KEY is required only
+  // for --broadcast (matches `agent publish` semantics from #51).
+  const keystorePwd = process.env[KEYSTORE_PWD_ENV];
+  if (!keystorePwd) {
+    fail(isJson, 2, `${KEYSTORE_PWD_ENV} env var is required (decrypts the owner keystore)`);
+  }
+  const pinataJwt = process.env.PINATA_JWT;
+  if (!pinataJwt) {
+    fail(isJson, 2, "PINATA_JWT env var is required (pins the new policy doc to IPFS)");
+  }
+
+  const chainLabel = options.chain ?? "base";
+  let chainResolved;
+  try {
+    chainResolved = resolveChain(chainLabel);
+  } catch (err) {
+    fail(isJson, 2, (err as Error).message);
+  }
+  const { chain, defaultRpc, defaultBundler } = chainResolved!;
+  const rpc = options.rpc ?? defaultRpc;
+  const bundlerUrl = options.bundler ?? defaultBundler;
+  const ttlHours = options.ttlHours !== undefined ? Number(options.ttlHours) : undefined;
+  if (ttlHours !== undefined && (!Number.isFinite(ttlHours) || ttlHours <= 0)) {
+    fail(isJson, 2, `--ttl-hours: invalid (got "${options.ttlHours}")`);
+  }
+  const gasCapWei = options.gasCapWei !== undefined ? BigInt(options.gasCapWei) : undefined;
+
+  // Read the keystore from the alias-keyed path. Issuance step #53 wrote
+  // it; rotation reads it without modifying.
+  const { homedir } = await import("node:os");
+  const { join } = await import("node:path");
+  const keystorePath = join(homedir(), ".synthesis", "keystores", `${options.alias}.json`);
+  let ownerKeystore: KeystoreJson;
+  try {
+    ownerKeystore = JSON.parse(readFileSync(keystorePath, "utf8"));
+  } catch (err) {
+    fail(
+      isJson,
+      2,
+      `cannot read keystore at ${keystorePath} (${(err as Error).message}). Did you run \`agent issue ${options.alias}\` first?`,
+    );
+  }
+
+  // Resolve resolver address (always, even for plan-only — needed for
+  // the publish-plan diff inside rotateAgent).
+  const config = getNetworkConfig("mainnet"); // ENS lives on mainnet regardless of agent's chain
+  const { fullName, node } = normalizeEnsName(options.ens, "mainnet");
+  const resolverAddress = await getResolver(node, "mainnet");
+  if (!resolverAddress) {
+    fail(isJson, 1, `No resolver found for ${fullName}`);
+  }
+
+  // For --broadcast mode: resolve the signer up-front + build the send
+  // callback. Use the same env-var convention as `agent publish` (#51):
+  // ENS_PRIVATE_KEY OR --ledger.
+  let signerAddress: `0x${string}` | null = null;
+  let send: ((calldata: `0x${string}`, target: `0x${string}`) => Promise<`0x${string}`>) | undefined;
+  if (options.broadcast) {
+    if (options.ledger) {
+      signerAddress = await getSignerAddressAsync(true, accountIndex);
+      if (!isJson) {
+        console.log(colors.green(`✓ Connected to Ledger`));
+        console.log(colors.dim(`  Address: ${signerAddress}`));
+      }
+    } else {
+      signerAddress = getSignerAddress();
+      if (!signerAddress) {
+        fail(isJson, 2, "ENS_PRIVATE_KEY not set (or use --ledger)");
+      }
+    }
+    send = async (calldata, target) => {
+      const wallet = await createChainWalletClient(
+        config!.chainId,
+        config!.rpcUrl,
+        !!options.ledger,
+        accountIndex,
+      );
+      if (!wallet || !wallet.account) {
+        throw new Error("Wallet client unavailable");
+      }
+      const hash = await wallet.sendTransaction({
+        account: wallet.account,
+        chain: wallet.chain,
+        to: target,
+        data: calldata,
+      });
+      return hash;
+    };
+  }
+
+  if (!isJson) {
+    startSpinner(
+      options.broadcast
+        ? `Rotating ${colors.cyan(fullName)} (broadcast)...`
+        : `Building rotation plan for ${colors.cyan(fullName)} (read-only)...`,
+    );
+  }
+
+  let result: RotateResult;
+  try {
+    result = await rotateAgent({
+      ensName: fullName,
+      alias: options.alias,
+      ownerKeystore,
+      ownerPassword: keystorePwd!,
+      chain,
+      chainLabel,
+      rpc,
+      bundlerUrl,
+      ipfsGateways: options.ipfsGateway,
+      newPolicyVersion: options.policyVersion,
+      newTtlHours: ttlHours,
+      newGasCapWei: gasCapWei,
+      pinataJwt: pinataJwt!,
+      resolverAddress: resolverAddress!,
+      broadcast: options.broadcast,
+      send,
+    });
+  } catch (err) {
+    stopSpinner();
+    if (options.ledger) await closeLedger();
+    fail(isJson, 1, (err as Error).message);
+  }
+
+  stopSpinner();
+
+  // For --broadcast: wait for receipt(s).
+  if (options.broadcast && result!.publishPlan.txHashes && result!.publishPlan.txHashes.length > 0) {
+    if (!isJson) startSpinner("Waiting for confirmations...");
+    const client = createChainPublicClient(config!.chainId, options.rpc ?? config!.rpcUrl);
+    for (const hash of result!.publishPlan.txHashes) {
+      const receipt = await client.waitForTransactionReceipt({
+        hash,
+        confirmations: 2,
+      });
+      if (receipt.status !== "success") {
+        stopSpinner();
+        if (options.ledger) await closeLedger();
+        fail(isJson, 1, `transaction ${hash} reverted`);
+      }
+    }
+    stopSpinner();
+  }
+
+  if (options.ledger) await closeLedger();
+
+  if (isJson) {
+    console.log(JSON.stringify({ ...result!, signer: signerAddress }, null, 2));
+  } else {
+    printRotation(result!, signerAddress);
+  }
+
+  process.exitCode = 0;
+  return result!;
+}
+
+function printRotation(r: RotateResult, signerAddress: `0x${string}` | null) {
+  console.log();
+  console.log(colors.bold("  Rotation Plan"));
+  console.log(colors.dim("  ─────────────"));
+  console.log(`    ENS name           : ${colors.cyan(r.ensName)}`);
+  console.log(`    Alias              : ${r.alias} → ${colors.cyan(r.newSessionKeyArtifact)}`);
+  console.log(`    Version bump       : ${colors.dim(r.fromVersion)} → ${colors.green(r.toVersion)}`);
+  console.log(`    runtime-pubkey     : ${colors.dim(r.fromRuntimePubkey.slice(0, 10) + "…")} → ${colors.green(r.toRuntimePubkey.slice(0, 10) + "…")}`);
+  console.log(`    new policy hash    : ${colors.green(r.newPolicy.hash)}`);
+  console.log(`    new policy URI     : ${colors.dim(r.newPolicy.uri)}`);
+  if (signerAddress) console.log(`    Signer             : ${colors.dim(signerAddress)}`);
+  console.log();
+
+  const plan = r.publishPlan;
+  console.log(colors.bold("  Publish (4 records changed, 5 carried forward)"));
+  console.log(colors.dim("  ────────────────────────────────────────────────"));
+  for (const d of plan.diffs ?? []) {
+    const rotated = ["runtime-pubkey", "delegation", "policy-hash", "policy-version"].includes(d.key);
+    if (d.changed) {
+      console.log(`    ${colors.yellow("●")} ${rotated ? colors.bold(d.key) : d.key}`);
+      console.log(`      ${colors.dim("from:")} ${colors.dim((d.current ?? "(unset)").slice(0, 80))}`);
+      console.log(`      ${colors.dim("  to:")} ${(d.next).slice(0, 80)}`);
+    } else {
+      console.log(`    ${colors.dim("·")} ${colors.dim(d.key.padEnd(20))} ${colors.dim("(unchanged)")}`);
+    }
+  }
+  console.log();
+  if (!r.broadcast) {
+    console.log(colors.dim(`  No --broadcast — multicall would be sent to ${plan.resolver}.`));
+    console.log(colors.dim(`  Re-run with ${colors.bold("--broadcast")} to send.`));
+  } else if (plan.txHashes) {
+    for (const h of plan.txHashes) {
+      console.log(`  ${colors.green("✓ tx:")} ${h}`);
+    }
+    console.log();
+    console.log(colors.dim(`  Verify with: ensemble agent verify ${r.ensName}`));
+  }
+  console.log();
+}

--- a/packages/cli/commands/agent-rotate.ts
+++ b/packages/cli/commands/agent-rotate.ts
@@ -217,10 +217,14 @@ export async function agentRotate(options: AgentRotateCliOptions): Promise<Rotat
 
   stopSpinner();
 
-  // For --broadcast: wait for receipt(s).
+  // For --broadcast: wait for receipt(s). The publish multicall lands on
+  // mainnet (ENS lives there), so polling MUST use the mainnet RPC, not
+  // `options.rpc` which is the Base smart-account RPC. Codex P1 caught
+  // this — passing the Base RPC to a chainId=1 client polls the wrong
+  // chain for a mainnet tx and times out.
   if (options.broadcast && result!.publishPlan.txHashes && result!.publishPlan.txHashes.length > 0) {
     if (!isJson) startSpinner("Waiting for confirmations...");
-    const client = createChainPublicClient(config!.chainId, options.rpc ?? config!.rpcUrl);
+    const client = createChainPublicClient(config!.chainId, config!.rpcUrl);
     for (const hash of result!.publishPlan.txHashes) {
       const receipt = await client.waitForTransactionReceipt({
         hash,

--- a/packages/cli/commands/index.ts
+++ b/packages/cli/commands/index.ts
@@ -20,6 +20,7 @@ export { agentVerify } from "./agent-verify";
 export { agentPin } from "./agent-pin";
 export { agentPublish } from "./agent-publish";
 export { agentIssue } from "./agent-issue";
+export { agentRotate } from "./agent-rotate";
 export { personhoodCheck, personhoodRegister } from "./personhood";
 export { trust } from "./trust";
 export { gate } from "./gate";

--- a/packages/cli/index.ts
+++ b/packages/cli/index.ts
@@ -32,6 +32,7 @@ import {
 	agentPin,
 	agentPublish,
 	agentIssue,
+	agentRotate,
 	personhoodCheck,
 	personhoodRegister,
 	trust as trustCmd,
@@ -1100,6 +1101,74 @@ agent.command("issue", {
 			ttlHours: options.ttlHours,
 			gasCapWei: options.gasCapWei,
 			index: options.index,
+			format: options.format,
+		});
+	},
+});
+
+agent.command("rotate", {
+	description:
+		"Rotate the active session key + bump the policy version on an ENS-bound agent. Plan-only by default; --broadcast sends the multicall (4 records: runtime-pubkey, delegation, policy-hash, policy-version). Reads $SYNTHESIS_KEYSTORE_PASSWORD + $PINATA_JWT (always); $ENS_PRIVATE_KEY or --ledger for --broadcast. Does NOT call onchain revokeSessionKey — TRL semantic is sufficient.",
+	args: z.object({
+		alias: z.string().describe("Existing alias from `agent issue` (filesystem keystore lookup)"),
+	}),
+	options: z.object({
+		ens: z
+			.string()
+			.describe("ENS name to rotate (e.g. emilemarcelagustin.eth)"),
+		policyVersion: z
+			.string()
+			.optional()
+			.describe("New policy version (default: auto-bump from on-chain policy-version)"),
+		ttlHours: z
+			.string()
+			.regex(/^\d+$/, "must be a positive integer (hours)")
+			.optional()
+			.describe("New session-key TTL in hours (default: 168)"),
+		gasCapWei: z
+			.string()
+			.regex(/^\d+$/, "must be a positive integer (wei)")
+			.optional()
+			.describe("New session-key gas cap in wei (default: 1000000000000000)"),
+		chain: z
+			.enum(["base", "base-sepolia"])
+			.optional()
+			.describe("Target chain for the smart-account (default: base)"),
+		rpc: z.string().optional().describe("Base RPC URL (must preserve eth_call revert data)"),
+		bundler: z.string().optional().describe("ERC-4337 bundler URL"),
+		ipfsGateway: z.array(z.string()).optional().describe("Override IPFS gateway race (repeatable)"),
+		broadcast: z.boolean().optional().describe("Send the multicall transaction. Default off."),
+		ledger: z.boolean().optional().describe("Sign via Ledger hardware wallet"),
+		accountIndex: z.string().optional().describe("Ledger account index (default: 0)"),
+		format: z.enum(["json"]).optional().describe("Emit a structured RotateResult on stdout"),
+	}),
+	alias: { broadcast: "B", format: "f" },
+	examples: [
+		{
+			args: { alias: "alpha" },
+			options: { ens: "emilemarcelagustin.eth" },
+			description: "Plan-only rotation: prints version bump + 4-record diff",
+		},
+		{
+			args: { alias: "alpha" },
+			options: { ens: "emilemarcelagustin.eth", broadcast: true },
+			description: "Broadcast the rotation",
+		},
+	],
+	async run({ args, options }) {
+		return await agentRotate({
+			alias: args.alias,
+			ens: options.ens,
+			policyVersion: options.policyVersion,
+			ttlHours: options.ttlHours,
+			gasCapWei: options.gasCapWei,
+			chain: options.chain,
+			rpc: options.rpc,
+			bundler: options.bundler,
+			ipfsGateway: options.ipfsGateway,
+			broadcast: options.broadcast,
+			ledger: options.ledger,
+			accountIndex: options.accountIndex,
 			format: options.format,
 		});
 	},

--- a/packages/resolver/src/index.ts
+++ b/packages/resolver/src/index.ts
@@ -156,3 +156,17 @@ export {
   type SmartAccountFile,
   type SessionKeyFile,
 } from "./wallets/namera-issue.js";
+
+export {
+  bumpPolicy,
+  nextMajorVersion,
+  type PolicyDoc,
+  type BumpPolicyArgs,
+} from "./wallets/policy-bump.js";
+
+export {
+  rotateAgent,
+  readRotationArtifact,
+  type RotateAgentArgs,
+  type RotateResult,
+} from "./wallets/rotate.js";

--- a/packages/resolver/src/wallets/policy-bump.test.ts
+++ b/packages/resolver/src/wallets/policy-bump.test.ts
@@ -1,0 +1,157 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
+import { keccak256, toHex } from "viem";
+import { bumpPolicy, nextMajorVersion, type PolicyDoc } from "./policy-bump.js";
+import { canonicalizeBytes } from "../utils/jcs.js";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const POLICY_PATH = resolve(
+  __dirname,
+  "../../test/fixtures/agent-verify/delegation-policy-v1.json",
+);
+
+function loadV1(): PolicyDoc {
+  return JSON.parse(readFileSync(POLICY_PATH, "utf8")) as PolicyDoc;
+}
+
+const NEW_KEY = "0x1111222233334444555566667777888899990000" as `0x${string}`;
+const FIXED_TIMESTAMP = "2026-05-12T00:00:00Z";
+
+test("bumpPolicy — produces valid v2 doc with the new session key + timestamp", () => {
+  const v1 = loadV1();
+  const v2 = bumpPolicy(v1, {
+    newVersion: "v2",
+    newSessionKeyAddress: NEW_KEY,
+    issuedAt: FIXED_TIMESTAMP,
+  });
+  assert.equal(v2.version, "v2");
+  assert.equal(v2["issued-at"], FIXED_TIMESTAMP);
+  assert.equal(v2["active-session-key"]?.address, NEW_KEY);
+  assert.equal(v2["active-session-key"]?.["issued-at"], FIXED_TIMESTAMP);
+});
+
+test("bumpPolicy — carries forward all non-rotated fields byte-for-byte", () => {
+  const v1 = loadV1();
+  const v2 = bumpPolicy(v1, {
+    newVersion: "v2",
+    newSessionKeyAddress: NEW_KEY,
+    issuedAt: FIXED_TIMESTAMP,
+  });
+  // delegators array carries forward verbatim
+  assert.deepEqual(v2.delegators, v1.delegators);
+  // delegation-policy semantics unchanged (scope, threshold, prohibited)
+  assert.deepEqual(v2["delegation-policy"], v1["delegation-policy"]);
+  // agent block unchanged (ens-name, kernel-wallet, chain, agent-id)
+  assert.deepEqual(v2.agent, v1.agent);
+  // revocation procedure unchanged
+  assert.deepEqual(v2.revocation, v1.revocation);
+  // kernel-wallet inside active-session-key carries forward
+  assert.equal(v2["active-session-key"]?.["kernel-wallet"], v1["active-session-key"]?.["kernel-wallet"]);
+});
+
+test("bumpPolicy — input doc is NOT mutated (deep clone semantics)", () => {
+  const v1 = loadV1();
+  const before = JSON.stringify(v1);
+  bumpPolicy(v1, {
+    newVersion: "v2",
+    newSessionKeyAddress: NEW_KEY,
+    issuedAt: FIXED_TIMESTAMP,
+  });
+  assert.equal(JSON.stringify(v1), before);
+});
+
+test("bumpPolicy — same inputs produce byte-identical JCS canonical output (purity test, Codex amendment 4)", () => {
+  // The function claims to be pure. Two calls with the same inputs
+  // must produce the same canonical bytes. Catches accidental Date.now()
+  // leaks at module-eval time, or hidden randomness.
+  const v1 = loadV1();
+  const a = bumpPolicy(v1, {
+    newVersion: "v2",
+    newSessionKeyAddress: NEW_KEY,
+    issuedAt: FIXED_TIMESTAMP,
+    newTtlHours: 24,
+  });
+  const b = bumpPolicy(v1, {
+    newVersion: "v2",
+    newSessionKeyAddress: NEW_KEY,
+    issuedAt: FIXED_TIMESTAMP,
+    newTtlHours: 24,
+  });
+  assert.equal(
+    keccak256(toHex(canonicalizeBytes(a as never))),
+    keccak256(toHex(canonicalizeBytes(b as never))),
+  );
+});
+
+test("bumpPolicy — newTtlHours overrides the carried-forward ttl", () => {
+  const v1 = loadV1();
+  const v2 = bumpPolicy(v1, {
+    newVersion: "v2",
+    newSessionKeyAddress: NEW_KEY,
+    issuedAt: FIXED_TIMESTAMP,
+    newTtlHours: 24,
+  });
+  assert.equal(v2["active-session-key"]?.["ttl-hours"], 24);
+});
+
+test("bumpPolicy — carries forward ttl when newTtlHours not provided", () => {
+  const v1 = loadV1();
+  const originalTtl = v1["active-session-key"]?.["ttl-hours"];
+  assert.ok(typeof originalTtl === "number", "fixture must have a ttl");
+  const v2 = bumpPolicy(v1, {
+    newVersion: "v2",
+    newSessionKeyAddress: NEW_KEY,
+    issuedAt: FIXED_TIMESTAMP,
+  });
+  assert.equal(v2["active-session-key"]?.["ttl-hours"], originalTtl);
+});
+
+test("bumpPolicy — bumps $id suffix when it ends in -vN.json", () => {
+  const v1 = loadV1();
+  // v1 fixture's $id is "https://emilemarcelagustin.eth.limo/policies/delegation-policy-v1.json"
+  assert.match(v1.$id ?? "", /-v1\.json$/);
+  const v2 = bumpPolicy(v1, {
+    newVersion: "v2",
+    newSessionKeyAddress: NEW_KEY,
+    issuedAt: FIXED_TIMESTAMP,
+  });
+  assert.match(v2.$id ?? "", /-v2\.json$/);
+});
+
+test("bumpPolicy — rejects invalid newVersion", () => {
+  const v1 = loadV1();
+  assert.throws(
+    () =>
+      bumpPolicy(v1, { newVersion: "2", newSessionKeyAddress: NEW_KEY, issuedAt: FIXED_TIMESTAMP }),
+    /invalid newVersion/,
+  );
+});
+
+test("bumpPolicy — rejects docs without active-session-key", () => {
+  const broken = { version: "v1" } as PolicyDoc;
+  assert.throws(
+    () =>
+      bumpPolicy(broken, {
+        newVersion: "v2",
+        newSessionKeyAddress: NEW_KEY,
+        issuedAt: FIXED_TIMESTAMP,
+      }),
+    /lacks "active-session-key"/,
+  );
+});
+
+test("nextMajorVersion — v1 → v2, v2 → v3, v1.2 → v2", () => {
+  assert.equal(nextMajorVersion("v1"), "v2");
+  assert.equal(nextMajorVersion("v2"), "v3");
+  assert.equal(nextMajorVersion("v1.2"), "v2");
+  assert.equal(nextMajorVersion("v9"), "v10");
+});
+
+test("nextMajorVersion — rejects malformed versions", () => {
+  assert.throws(() => nextMajorVersion("1"), /invalid current version/);
+  assert.throws(() => nextMajorVersion("v"), /invalid current version/);
+  assert.throws(() => nextMajorVersion("Va1"), /invalid current version/);
+});

--- a/packages/resolver/src/wallets/policy-bump.ts
+++ b/packages/resolver/src/wallets/policy-bump.ts
@@ -1,0 +1,108 @@
+/**
+ * Pure policy-doc version-bump helper.
+ *
+ * Carries forward all non-rotated fields byte-for-byte. Mutates only:
+ *   - `version`
+ *   - `active-session-key.address`
+ *   - `active-session-key.issued-at`
+ *   - `active-session-key.ttl-hours` (when `newTtlHours` is provided)
+ *   - top-level `issued-at`
+ *
+ * No IO. No `Date.now()` at module-eval (the test in policy-bump.test.ts
+ * asserts byte-identical JCS output across two calls with the same
+ * inputs, which catches accidental impurity).
+ */
+
+import type { Address } from "viem";
+
+export interface PolicyDoc {
+  $schema?: string;
+  $id?: string;
+  "schema-uri"?: string;
+  agent?: { "ens-name"?: string; [k: string]: unknown };
+  version?: string;
+  "issued-at"?: string;
+  delegators?: unknown[];
+  "delegation-policy"?: {
+    threshold?: string;
+    scope?: string[];
+    "ttl-hours"?: number;
+    "permitted-message-classes"?: string[];
+    prohibited?: string[];
+  };
+  "active-session-key"?: {
+    address?: string;
+    "issued-at"?: string;
+    "ttl-hours"?: number;
+    "kernel-wallet"?: string;
+  };
+  revocation?: unknown;
+  [k: string]: unknown;
+}
+
+export interface BumpPolicyArgs {
+  newVersion: string; // e.g. "v2"
+  newSessionKeyAddress: Address;
+  /**
+   * RFC 3339 timestamp. REQUIRED — we don't default to `Date.now()`
+   * because that would make the function impure (two calls with the
+   * same inputs would produce different bytes). Caller mints the
+   * timestamp explicitly so it can be controlled in tests + replayed
+   * for verification.
+   */
+  issuedAt: string;
+  /** Optional TTL override; carried forward from the current doc when omitted. */
+  newTtlHours?: number;
+}
+
+const VERSION_RE = /^v[0-9]+(\.[0-9]+){0,2}$/;
+
+export function bumpPolicy(currentDoc: PolicyDoc, args: BumpPolicyArgs): PolicyDoc {
+  if (!VERSION_RE.test(args.newVersion)) {
+    throw new Error(`bumpPolicy: invalid newVersion "${args.newVersion}" (expected v<N>[.<M>[.<P>]])`);
+  }
+  if (!currentDoc["active-session-key"]) {
+    throw new Error(
+      `bumpPolicy: current doc lacks "active-session-key" — input is not a v1+ delegation policy`,
+    );
+  }
+
+  const ttl =
+    args.newTtlHours ??
+    currentDoc["active-session-key"]["ttl-hours"] ??
+    currentDoc["delegation-policy"]?.["ttl-hours"] ??
+    168;
+
+  // Structural clone the carry-forward fields. Use JSON round-trip for
+  // a deep clone so nested object identity doesn't leak into the new doc.
+  const next = JSON.parse(JSON.stringify(currentDoc)) as PolicyDoc;
+  next.version = args.newVersion;
+  next["issued-at"] = args.issuedAt;
+  next["active-session-key"] = {
+    ...next["active-session-key"]!,
+    address: args.newSessionKeyAddress,
+    "issued-at": args.issuedAt,
+    "ttl-hours": ttl,
+  };
+  // Bump the top-level $id suffix too if it has a /vN.json shape, so the
+  // doc remains self-describing. Best-effort — leave as-is if no match.
+  if (typeof next.$id === "string") {
+    next.$id = next.$id.replace(/-v[0-9]+(\.[0-9]+){0,2}\.json$/, `-${args.newVersion}.json`);
+  }
+  return next;
+}
+
+/**
+ * Parse an on-chain `policy-version` text record like "v1" or "v1.2"
+ * and return the next major version: "v1" → "v2", "v1.2" → "v2".
+ * Major bumps only — minor/patch revisions aren't part of the rotation
+ * spec; they'd indicate a non-rotation policy edit which is out of
+ * scope (issue #54 §"Out of scope").
+ */
+export function nextMajorVersion(current: string): string {
+  if (!VERSION_RE.test(current)) {
+    throw new Error(`nextMajorVersion: invalid current version "${current}"`);
+  }
+  const major = parseInt(current.slice(1).split(".")[0], 10);
+  return `v${major + 1}`;
+}

--- a/packages/resolver/src/wallets/rotate.test.ts
+++ b/packages/resolver/src/wallets/rotate.test.ts
@@ -250,9 +250,42 @@ test("rotateAgent — pin step uses the bumped relpath under policies/", async (
       },
     }),
   );
-  assert.ok(pinnedFiles && pinnedFiles.length === 2);
-  const relpaths = pinnedFiles!.map((f) => f.relpath).sort();
+  // Local cast — TS strict mode in CI narrows closure-captured lets to
+  // `never` when assigned through a generic-typed callback.
+  const captured = pinnedFiles as
+    | { relpath: string; bytes: Uint8Array }[]
+    | null;
+  assert.ok(captured && captured.length === 2);
+  const relpaths = captured.map((f) => f.relpath).sort();
   assert.deepEqual(relpaths, ["ROTATION.txt", "policies/delegation-policy-v2.json"]);
+});
+
+test("rotateAgent — resolverAddress fallback honors optional contract via ENS registry lookup (Codex P2)", async () => {
+  // The fallback used to hard-throw, breaking the documented optional
+  // contract. Now it should call the public client's readContract for
+  // ENS Registry's `resolver(bytes32)`. Stub the client so we don't
+  // hit a real RPC.
+  const args = baseArgs();
+  // Strip the explicit resolverAddress so the fallback runs.
+  delete (args as Partial<RotateAgentArgs>).resolverAddress;
+  // Intercept readContract for the registry call. The orchestrator
+  // creates its own publicClient internally; we can't easily stub that
+  // without exposing a hook. Instead, set ensRpcUrl to an obviously bogus
+  // value and verify the error names the registry, not "--resolver-address
+  // is required".
+  args.ensRpcUrl = "http://127.0.0.1:1"; // unreachable
+  await assert.rejects(
+    () => rotateAgent(args),
+    (err: Error) => {
+      // Either the registry lookup fails (network error) or the resolver
+      // returns zero — both prove the fallback path was actually taken.
+      assert.ok(
+        !/-resolver-address is required/.test(err.message),
+        `must not throw the legacy hard-fail message; got: ${err.message}`,
+      );
+      return true;
+    },
+  );
 });
 
 test("rotateAgent — broadcast: true threads through to publishAgentRecords", async () => {

--- a/packages/resolver/src/wallets/rotate.test.ts
+++ b/packages/resolver/src/wallets/rotate.test.ts
@@ -1,0 +1,287 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
+import { base } from "viem/chains";
+import { keccak256, toHex } from "viem";
+import { rotateAgent, type RotateAgentArgs } from "./rotate.js";
+import { canonicalizeBytes } from "../utils/jcs.js";
+import { createKeystore } from "./keystore.js";
+import type { PolicyDoc } from "./policy-bump.js";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const FIXTURE_DIR = resolve(__dirname, "../../test/fixtures/agent-verify");
+
+const POLICY_BYTES = readFileSync(resolve(FIXTURE_DIR, "delegation-policy-v1.json"));
+const POLICY_OBJ = JSON.parse(POLICY_BYTES.toString("utf8")) as PolicyDoc;
+
+const RECORDS = JSON.parse(
+  readFileSync(resolve(FIXTURE_DIR, "records.json"), "utf8"),
+) as { records: Record<string, string>; ownerAddress: string };
+
+const FIXED_TS = "2026-05-12T00:00:00Z";
+const NEW_CID = "bafybeiNEWCID000000000000000000000000000000000000000000000000000ab";
+const NEW_SESSION_KEY = "0x0001020304050607080900010203040506070809" as `0x${string}`;
+
+const TEST_OWNER_PK = "0x4444444444444444444444444444444444444444444444444444444444444444";
+const TEST_OWNER_PWD = "owner-pass";
+const ownerKeystore = createKeystore({ privateKey: TEST_OWNER_PK, password: TEST_OWNER_PWD });
+
+function baseArgs(overrides?: Partial<RotateAgentArgs>): RotateAgentArgs {
+  return {
+    ensName: "emilemarcelagustin.eth",
+    alias: "alpha",
+    ownerKeystore,
+    ownerPassword: TEST_OWNER_PWD,
+    chain: base,
+    chainLabel: "base",
+    rpc: "rpc",
+    bundlerUrl: "bundler",
+    pinataJwt: "TEST_JWT",
+    issuedAt: FIXED_TS,
+    resolverAddress: "0xF29100983E058B709F3D539b0c765937B804AC15" as `0x${string}`,
+    testHooks: {
+      readRecords: async () => RECORDS.records,
+      fetchIpfs: async () => ({
+        bytes: new Uint8Array(POLICY_BYTES),
+        gateway: "fixture",
+      }),
+      pinDirectory: async (files, opts) => ({
+        cid: NEW_CID,
+        files: files.map((f) => ({
+          relpath: f.relpath,
+          ipfsUri: `ipfs://${NEW_CID}/${f.relpath}`,
+          gatewayUrl: `https://${opts.gateway ?? "gateway.pinata.cloud"}/ipfs/${NEW_CID}/${f.relpath}`,
+        })),
+      }),
+      issueSessionKey: (async () => ({
+        alias: "alpha-policy-v2",
+        sessionKeyAddress: NEW_SESSION_KEY,
+        kernelWallet: RECORDS.records["kernel-wallet"] as `0x${string}`,
+        chain: "base",
+        chainId: 8453,
+        validUntil: 0,
+        ttlHours: 168,
+        sessionKeyPath: "/tmp/fake-alpha-policy-v2.json",
+        created: true,
+      })) as never,
+      publishAgentRecords: (async (
+        ensName: string,
+        records: Record<string, string>,
+      ) => ({
+        ensName,
+        resolver: "0xF29100983E058B709F3D539b0c765937B804AC15" as `0x${string}`,
+        records: Object.entries(records).map(([key, value]) => ({ key, value })),
+        diffs: null,
+        setTextCalls: [],
+        broadcast: false,
+      })) as never,
+    },
+    ...overrides,
+  };
+}
+
+test("rotateAgent — happy path: bumps v1 to v2, generates new artifact name + ipfs URI", async () => {
+  const r = await rotateAgent(baseArgs());
+  assert.equal(r.fromVersion, "v1");
+  assert.equal(r.toVersion, "v2");
+  assert.equal(r.alias, "alpha");
+  // Codex amendment 1: artifact name follows policy version, not previous-suffix counter.
+  assert.equal(r.newSessionKeyArtifact, "alpha-policy-v2");
+  assert.equal(r.toRuntimePubkey, NEW_SESSION_KEY);
+  assert.equal(r.newPolicy.uri, `ipfs://${NEW_CID}/policies/delegation-policy-v2.json`);
+  assert.equal(r.newPolicy.version, "v2");
+  assert.match(r.newPolicy.hash, /^0x[0-9a-f]{64}$/);
+  assert.equal(r.broadcast, false);
+});
+
+test("rotateAgent — newPolicy.hash matches keccak256(JCS(bumped-doc))", async () => {
+  // Compute the expected hash locally using the same canonicalizer the
+  // verifier uses. If the orchestrator drifts (e.g. someone introduces
+  // an alternate canonicalization), this catches it.
+  const expectedDoc = {
+    ...POLICY_OBJ,
+    version: "v2",
+    "issued-at": FIXED_TS,
+    $id: POLICY_OBJ.$id?.replace(/-v1\.json$/, "-v2.json"),
+    "active-session-key": {
+      ...POLICY_OBJ["active-session-key"]!,
+      address: NEW_SESSION_KEY,
+      "issued-at": FIXED_TS,
+      "ttl-hours": POLICY_OBJ["active-session-key"]!["ttl-hours"],
+    },
+  };
+  const expectedHash = keccak256(toHex(canonicalizeBytes(expectedDoc as never)));
+  const r = await rotateAgent(baseArgs());
+  assert.equal(r.newPolicy.hash, expectedHash);
+});
+
+test("rotateAgent — explicit --policy-version overrides auto-bump", async () => {
+  const r = await rotateAgent(baseArgs({ newPolicyVersion: "v5" }));
+  assert.equal(r.toVersion, "v5");
+  assert.equal(r.newSessionKeyArtifact, "alpha-policy-v5");
+  assert.equal(r.newPolicy.uri, `ipfs://${NEW_CID}/policies/delegation-policy-v5.json`);
+});
+
+test("rotateAgent — refuses when name has no current policy-version (precondition)", async () => {
+  const recordsNoPolicy = { ...RECORDS.records };
+  delete (recordsNoPolicy as Record<string, string>)["policy-version"];
+  await assert.rejects(
+    () =>
+      rotateAgent(
+        baseArgs({
+          testHooks: {
+            ...baseArgs().testHooks,
+            readRecords: async () => recordsNoPolicy,
+          },
+        }),
+      ),
+    /lacks an existing policy/,
+  );
+});
+
+test("rotateAgent — refuses when name has no delegation URI", async () => {
+  const recordsNoDelegation = { ...RECORDS.records };
+  delete (recordsNoDelegation as Record<string, string>).delegation;
+  await assert.rejects(
+    () =>
+      rotateAgent(
+        baseArgs({
+          testHooks: { ...baseArgs().testHooks, readRecords: async () => recordsNoDelegation },
+        }),
+      ),
+    /lacks an existing policy/,
+  );
+});
+
+test("rotateAgent — publish plan covers the 4 changed records and carries forward the rest", async () => {
+  let receivedRecords: Record<string, string> | null = null;
+  const r = await rotateAgent(
+    baseArgs({
+      testHooks: {
+        ...baseArgs().testHooks,
+        publishAgentRecords: (async (
+          ensName: string,
+          records: Record<string, string>,
+        ) => {
+          receivedRecords = records;
+          return {
+            ensName,
+            resolver: "0xF29100983E058B709F3D539b0c765937B804AC15" as `0x${string}`,
+            records: Object.entries(records).map(([key, value]) => ({ key, value })),
+            diffs: null,
+            setTextCalls: [],
+            broadcast: false,
+          };
+        }) as never,
+      },
+    }),
+  );
+  assert.ok(receivedRecords, "publishAgentRecords must have been invoked");
+  // Changed values:
+  assert.equal((receivedRecords as Record<string, string>)["runtime-pubkey"], NEW_SESSION_KEY);
+  assert.equal(
+    (receivedRecords as Record<string, string>)["policy-hash"],
+    r.newPolicy.hash,
+  );
+  assert.equal((receivedRecords as Record<string, string>)["policy-version"], "v2");
+  assert.equal(
+    (receivedRecords as Record<string, string>)["delegation"],
+    `ipfs://${NEW_CID}/policies/delegation-policy-v2.json`,
+  );
+  // Carried-forward values:
+  assert.equal(
+    (receivedRecords as Record<string, string>)["kernel-wallet"],
+    RECORDS.records["kernel-wallet"],
+  );
+  assert.equal(
+    (receivedRecords as Record<string, string>)["agent-endpoint[web]"],
+    RECORDS.records["agent-endpoint[web]"],
+  );
+  assert.equal((receivedRecords as Record<string, string>).schema, RECORDS.records.schema);
+});
+
+test("rotateAgent — issueSessionKey is called under the versioned alias (not base alias)", async () => {
+  let receivedAlias: string | null = null;
+  await rotateAgent(
+    baseArgs({
+      testHooks: {
+        ...baseArgs().testHooks,
+        issueSessionKey: (async (opts: { alias: string }) => {
+          receivedAlias = opts.alias;
+          return {
+            alias: opts.alias,
+            sessionKeyAddress: NEW_SESSION_KEY,
+            kernelWallet: RECORDS.records["kernel-wallet"] as `0x${string}`,
+            chain: "base",
+            chainId: 8453,
+            validUntil: 0,
+            ttlHours: 168,
+            sessionKeyPath: `/tmp/${opts.alias}.json`,
+            created: true,
+          };
+        }) as never,
+      },
+    }),
+  );
+  // Codex amendment 1: alias is `<base>-policy-v<N>`, where N is the new
+  // on-chain version, NOT a previous-suffix increment.
+  assert.equal(receivedAlias, "alpha-policy-v2");
+});
+
+test("rotateAgent — pin step uses the bumped relpath under policies/", async () => {
+  let pinnedFiles: { relpath: string; bytes: Uint8Array }[] | null = null;
+  await rotateAgent(
+    baseArgs({
+      testHooks: {
+        ...baseArgs().testHooks,
+        pinDirectory: async (files, opts) => {
+          pinnedFiles = files;
+          return {
+            cid: NEW_CID,
+            files: files.map((f) => ({
+              relpath: f.relpath,
+              ipfsUri: `ipfs://${NEW_CID}/${f.relpath}`,
+              gatewayUrl: `https://${opts.gateway ?? "gateway.pinata.cloud"}/ipfs/${NEW_CID}/${f.relpath}`,
+            })),
+          };
+        },
+      },
+    }),
+  );
+  assert.ok(pinnedFiles && pinnedFiles.length === 2);
+  const relpaths = pinnedFiles!.map((f) => f.relpath).sort();
+  assert.deepEqual(relpaths, ["ROTATION.txt", "policies/delegation-policy-v2.json"]);
+});
+
+test("rotateAgent — broadcast: true threads through to publishAgentRecords", async () => {
+  let receivedBroadcast: boolean | undefined;
+  await rotateAgent(
+    baseArgs({
+      broadcast: true,
+      send: async () => "0xdeadbeef" as `0x${string}`,
+      testHooks: {
+        ...baseArgs().testHooks,
+        publishAgentRecords: (async (
+          _ensName: string,
+          _records: Record<string, string>,
+          _client: unknown,
+          opts: { broadcast?: boolean },
+        ) => {
+          receivedBroadcast = opts.broadcast;
+          return {
+            ensName: "emilemarcelagustin.eth",
+            resolver: "0xF29100983E058B709F3D539b0c765937B804AC15" as `0x${string}`,
+            records: [],
+            diffs: null,
+            setTextCalls: [],
+            broadcast: !!opts.broadcast,
+            txHashes: ["0xdeadbeef"],
+          };
+        }) as never,
+      },
+    }),
+  );
+  assert.equal(receivedBroadcast, true);
+});

--- a/packages/resolver/src/wallets/rotate.ts
+++ b/packages/resolver/src/wallets/rotate.ts
@@ -31,7 +31,7 @@ import {
   type Chain,
 } from "viem";
 import { canonicalizeBytes } from "../utils/jcs.js";
-import { getTextRecords, getOwner } from "../utils/ens.js";
+import { getTextRecords } from "../utils/ens.js";
 import { fetchIpfsRaw } from "../utils/ipfs.js";
 import {
   pinDirectory,
@@ -303,28 +303,45 @@ async function readRecords(
   );
 }
 
+/** Mainnet ENS Registry (deterministic across networks that use the
+ * canonical deployment). Mirrors the constant in utils/ens.ts. */
+const ENS_REGISTRY: Address = "0x00000000000C2E074eC69A0dFb2997BA6C7d2e1e";
+const REGISTRY_ABI = [
+  {
+    type: "function",
+    name: "resolver",
+    stateMutability: "view",
+    inputs: [{ name: "node", type: "bytes32" }],
+    outputs: [{ name: "", type: "address" }],
+  },
+] as const;
+
 async function defaultResolverFor(
   args: RotateAgentArgs,
   // biome-ignore lint/suspicious/noExplicitAny: viem's PublicClient generic
   client: any,
 ): Promise<Address> {
-  // Best-effort fallback: ask the registry for the resolver of the name.
-  // If that fails, the caller should pass --rpc to a Base RPC AND
-  // --resolver-address explicitly. The CLI does this lookup before
-  // calling rotateAgent so this branch shouldn't usually fire.
-  const { mainnet } = await import("viem/chains");
-  void mainnet;
-  void getOwner;
-  // Use ens-resolver-from-name pattern:
-  const ensClient = createPublicClient({
-    chain: { ...args.chain, id: 1 } as Chain,
-    transport: http(),
-  });
-  void ensClient;
-  void client;
-  throw new Error(
-    "rotateAgent: --resolver-address is required (CLI auto-resolves; library callers must pass)",
-  );
+  // Honor the documented optional contract: if the caller doesn't
+  // pre-supply resolverAddress, look it up from the ENS registry on
+  // mainnet. The `client` passed in is already configured for mainnet
+  // (constructed in the orchestrator above), so reuse it. Codex P2
+  // pointed out the previous fallback hard-threw, breaking non-CLI
+  // consumers of the optional field.
+  const { namehash } = await import("viem");
+  const { normalize } = await import("viem/ens");
+  const node = namehash(normalize(args.ensName));
+  const resolver = (await client.readContract({
+    address: ENS_REGISTRY,
+    abi: REGISTRY_ABI,
+    functionName: "resolver",
+    args: [node],
+  })) as Address;
+  if (resolver === "0x0000000000000000000000000000000000000000") {
+    throw new Error(
+      `rotateAgent: ENS registry returned no resolver for ${args.ensName} (zero address). The name may not exist on mainnet.`,
+    );
+  }
+  return resolver;
 }
 
 /**

--- a/packages/resolver/src/wallets/rotate.ts
+++ b/packages/resolver/src/wallets/rotate.ts
@@ -1,0 +1,345 @@
+/**
+ * `rotateAgent` — orchestrates the 4-step session-key rotation:
+ *
+ *   1. Read on-chain ENS records (fail if no current policy-version + delegation).
+ *   2. Fetch current policy doc via IPFS + canonicalize for hash baseline.
+ *   3. Issue a fresh session-key under a versioned filename
+ *      `<alias>-policy-v<N>.json` where N is the new on-chain version
+ *      (NOT a previous-suffix increment — filesystem mirrors published state).
+ *   4. Author bumped policy, write to ephemeral tmpdir, pin via Pinata,
+ *      compute new policy-hash, build the 4-record publish plan.
+ *
+ * Read-only by default. The plan-only path returns a `PublishPlan` with
+ * `broadcast: false` (matches `agent publish` semantics from #51).
+ *
+ * Does NOT call `revokeSessionKey`. Off-chain semantic — once the
+ * `runtime-pubkey` ENS record points at the new signer, verifiers must
+ * reject signatures from the old key. On-chain revoke is gas the operator
+ * can pay later via a `--revoke-onchain` follow-up flag (out of scope
+ * for this PR per issue #54 §"Out of scope").
+ */
+
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  createPublicClient,
+  http,
+  keccak256,
+  toHex,
+  type Address,
+  type Chain,
+} from "viem";
+import { canonicalizeBytes } from "../utils/jcs.js";
+import { getTextRecords, getOwner } from "../utils/ens.js";
+import { fetchIpfsRaw } from "../utils/ipfs.js";
+import {
+  pinDirectory,
+  type PinDirectoryResult,
+} from "../utils/pinata.js";
+import {
+  publishAgentRecords,
+  type AgentPublishRecords,
+  type PublishOptions,
+  type PublishPlan,
+} from "../utils/agent-publish.js";
+import { issueSessionKey, type IssueSessionKeyOptions } from "./namera-issue.js";
+import { bumpPolicy, nextMajorVersion, type PolicyDoc } from "./policy-bump.js";
+import type { KeystoreJson } from "./keystore.js";
+
+// =============================================================================
+// Public types
+// =============================================================================
+
+export interface RotateAgentArgs {
+  ensName: string;
+  /** Base alias (the one passed to `agent issue`). */
+  alias: string;
+  ownerKeystore: KeystoreJson;
+  ownerPassword: string;
+  /** Smart-account's chain (e.g. base). Used for the SDK calls only. */
+  chain: Chain;
+  chainLabel: string;
+  /** RPC for the smart-account's chain. MUST preserve eth_call revert
+   * data (Alchemy, Tenderly Gateway, etc.) — see #53. */
+  rpc: string;
+  bundlerUrl: string;
+  /**
+   * Mainnet RPC used to read + write ENS text records. ENS lives on
+   * mainnet regardless of where the smart-account is. Defaults to the
+   * resolver's standard mainnet RPC (eth.drpc.org).
+   */
+  ensRpcUrl?: string;
+  ipfsGateways?: string[];
+  /** When omitted, auto-bumps from on-chain `policy-version`. */
+  newPolicyVersion?: string;
+  newTtlHours?: number;
+  newGasCapWei?: bigint;
+  /** Smart-account index used at issuance. Defaults 0n. */
+  index?: bigint;
+  kernelVersion?: string;
+  /** RFC 3339 timestamp for both top-level and active-session-key issued-at.
+   * Caller-supplied so the function stays pure for tests. Default: now. */
+  issuedAt?: string;
+  /** Pinata JWT — required for the pin step. */
+  pinataJwt: string;
+  pinataMetadataName?: string;
+  pinataGateway?: string;
+  /** ENS resolver address. Read from chain unless provided. */
+  resolverAddress?: Address;
+  /** Operator-supplied. When false (default), no transaction is broadcast. */
+  broadcast?: boolean;
+  /** When `broadcast: true`, a callback that signs + sends the multicall. */
+  send?: PublishOptions["send"];
+  /** Inject for tests. */
+  testHooks?: {
+    readRecords?: (
+      ensName: string,
+      keys: readonly string[],
+    ) => Promise<Record<string, string>>;
+    fetchIpfs?: (uri: string) => Promise<{ bytes: Uint8Array; gateway: string }>;
+    pinDirectory?: typeof pinDirectory;
+    issueSessionKey?: typeof issueSessionKey;
+    publishAgentRecords?: typeof publishAgentRecords;
+  };
+}
+
+export interface RotateResult {
+  ensName: string;
+  alias: string;
+  /** Filesystem artifact name carrying the new session-key:
+   *  `<alias>-policy-v<N>.json` where N is the new on-chain version
+   *  (NOT a previous-suffix increment — mirrors published state). */
+  newSessionKeyArtifact: string;
+  fromVersion: string;
+  toVersion: string;
+  fromRuntimePubkey: string;
+  toRuntimePubkey: string;
+  newPolicy: { hash: string; uri: string; version: string };
+  publishPlan: PublishPlan;
+  broadcast: boolean;
+}
+
+// The 9 ENSIP-64 keys we read up-front. Imported as a const here so the
+// rotate module doesn't take a hard dep on agent-verify just for the
+// constant's value — duplicate is cheap, version drift is unlikely.
+const AGENT_RECORD_KEYS = [
+  "class",
+  "schema",
+  "runtime-pubkey",
+  "runtime-status",
+  "kernel-wallet",
+  "agent-endpoint[web]",
+  "delegation",
+  "policy-hash",
+  "policy-version",
+] as const;
+
+// =============================================================================
+// Orchestrator
+// =============================================================================
+
+export async function rotateAgent(args: RotateAgentArgs): Promise<RotateResult> {
+  const issuedAt = args.issuedAt ?? new Date().toISOString();
+  const ipfsGateways = args.ipfsGateways;
+  const fetchHook = args.testHooks?.fetchIpfs;
+
+  const records = await readRecords(args);
+
+  // 1) Validate the precondition: rotation requires an existing v1 (+) policy.
+  const fromVersion = records["policy-version"];
+  const fromDelegationUri = records.delegation;
+  const fromRuntimePubkey = records["runtime-pubkey"];
+  if (!fromVersion || !fromDelegationUri || !fromRuntimePubkey) {
+    throw new Error(
+      `agent rotate ${args.ensName}: name lacks an existing policy. Required ENS records: policy-version, delegation, runtime-pubkey. Run \`agent publish\` first.`,
+    );
+  }
+  const toVersion = args.newPolicyVersion ?? nextMajorVersion(fromVersion);
+
+  // 2) Fetch the current policy doc.
+  const fetched = fetchHook
+    ? await fetchHook(fromDelegationUri)
+    : await fetchIpfsRaw(fromDelegationUri, { gateways: ipfsGateways });
+  const currentPolicy = JSON.parse(new TextDecoder().decode(fetched.bytes)) as PolicyDoc;
+
+  // 3) Issue a fresh session-key under the new versioned alias.
+  // The artifact name encodes the NEW policy version so the on-disk file
+  // matches what's published. Same as the alias-keyed convention from
+  // `agent issue` (#53), just with a deterministic suffix tied to the
+  // version, not to a counter.
+  const newSessionKeyArtifact = `${args.alias}-policy-${toVersion}`;
+  const issueFn = args.testHooks?.issueSessionKey ?? issueSessionKey;
+  const issueArgs: IssueSessionKeyOptions = {
+    alias: newSessionKeyArtifact,
+    ownerKeystore: args.ownerKeystore,
+    ownerPassword: args.ownerPassword,
+    chain: args.chain,
+    chainLabel: args.chainLabel,
+    rpc: args.rpc,
+    bundlerUrl: args.bundlerUrl,
+    kernelVersion: args.kernelVersion,
+    index: args.index,
+    ttlHours: args.newTtlHours,
+    gasCapWei: args.newGasCapWei,
+  };
+  const issued = await issueFn(issueArgs);
+  const toRuntimePubkey = issued.sessionKeyAddress;
+
+  // 4) Author the bumped policy doc.
+  const newPolicy = bumpPolicy(currentPolicy, {
+    newVersion: toVersion,
+    newSessionKeyAddress: toRuntimePubkey,
+    issuedAt,
+    newTtlHours: args.newTtlHours,
+  });
+  const newPolicyHash = keccak256(toHex(canonicalizeBytes(newPolicy as never)));
+
+  // 5) Pin the new policy. We write it to an ephemeral tmpdir alongside
+  // a sentinel file (Pinata flattens single-file pins) and remove the
+  // tmpdir as soon as Pinata returns the CID. The CID is the durable
+  // artifact; the local tmpdir is a transient.
+  const policyRelpath = `policies/delegation-policy-${toVersion}.json`;
+  const pinFn = args.testHooks?.pinDirectory ?? pinDirectory;
+  const tmp = mkdtempSync(join(tmpdir(), `agent-rotate-${args.alias}-`));
+  let pinResult: PinDirectoryResult;
+  try {
+    const policyBytes = canonicalizeBytes(newPolicy as never);
+    const sentinelPath = join(tmp, "ROTATION.txt");
+    const policyFullPath = join(tmp, policyRelpath);
+    writeFileSync(
+      sentinelPath,
+      `Rotation artifact for ${args.ensName} ${fromVersion} → ${toVersion}. CID-only; safe to discard.`,
+    );
+    // Recreate parent dirs for the relpath inside tmpdir.
+    const { mkdirSync } = await import("node:fs");
+    mkdirSync(join(tmp, "policies"), { recursive: true });
+    writeFileSync(policyFullPath, policyBytes);
+
+    pinResult = await pinFn(
+      [
+        { relpath: "ROTATION.txt", bytes: new Uint8Array(readFileSync(sentinelPath)) },
+        { relpath: policyRelpath, bytes: new Uint8Array(readFileSync(policyFullPath)) },
+      ],
+      {
+        jwt: args.pinataJwt,
+        metadataName:
+          args.pinataMetadataName ?? `${args.alias}-policy-${toVersion}`,
+        gateway: args.pinataGateway,
+      },
+    );
+  } finally {
+    rmSync(tmp, { recursive: true, force: true });
+  }
+
+  const newDelegationUri = `ipfs://${pinResult.cid}/${policyRelpath}`;
+
+  // 6) Build the 4-record publish plan via #51's publishAgentRecords.
+  // Optional records (delegation/policy-hash/policy-version) carry the
+  // new values; required records that aren't changing carry their
+  // current values so #51's record-set assembly stays happy.
+  const publishFn = args.testHooks?.publishAgentRecords ?? publishAgentRecords;
+  const fullRecords: AgentPublishRecords = {
+    schema: records.schema,
+    "runtime-pubkey": toRuntimePubkey,
+    "runtime-status": (records["runtime-status"] ??
+      "active") as AgentPublishRecords["runtime-status"],
+    "kernel-wallet": records["kernel-wallet"],
+    "agent-endpoint[web]": records["agent-endpoint[web]"],
+    delegation: newDelegationUri,
+    "policy-hash": newPolicyHash,
+    "policy-version": toVersion,
+  };
+  // publishAgentRecords reads/writes ENS records, which live on mainnet
+  // — not on the agent's smart-account chain. Use the mainnet RPC.
+  const { mainnet } = await import("viem/chains");
+  const client = createPublicClient({
+    chain: mainnet,
+    transport: http(args.ensRpcUrl ?? "https://eth.drpc.org"),
+  });
+  // Resolver address: caller may pre-supply (CLI does the lookup); else
+  // we fall back to the chain's default ENS resolver via getOwner-side
+  // utilities. Required for publishAgentRecords' diff.
+  const resolverAddress = args.resolverAddress ?? (await defaultResolverFor(args, client));
+  const publishPlan = await publishFn(args.ensName, fullRecords, client, {
+    resolverAddress,
+    multicall: true,
+    legacyAliases: false,
+    broadcast: args.broadcast ?? false,
+    send: args.send,
+  });
+
+  return {
+    ensName: args.ensName,
+    alias: args.alias,
+    newSessionKeyArtifact,
+    fromVersion,
+    toVersion,
+    fromRuntimePubkey,
+    toRuntimePubkey,
+    newPolicy: { hash: newPolicyHash, uri: newDelegationUri, version: toVersion },
+    publishPlan,
+    broadcast: !!args.broadcast,
+  };
+}
+
+async function readRecords(
+  args: RotateAgentArgs,
+): Promise<Record<string, string>> {
+  if (args.testHooks?.readRecords) {
+    return args.testHooks.readRecords(args.ensName, AGENT_RECORD_KEYS);
+  }
+  // ENS lives on mainnet, not the agent's smart-account chain. Reading
+  // text records against args.chain (Base) silently returns empty.
+  const { mainnet } = await import("viem/chains");
+  const client = createPublicClient({
+    chain: mainnet,
+    transport: http(args.ensRpcUrl ?? "https://eth.drpc.org"),
+  });
+  return getTextRecords(
+    client,
+    args.ensName,
+    AGENT_RECORD_KEYS as unknown as string[],
+  );
+}
+
+async function defaultResolverFor(
+  args: RotateAgentArgs,
+  // biome-ignore lint/suspicious/noExplicitAny: viem's PublicClient generic
+  client: any,
+): Promise<Address> {
+  // Best-effort fallback: ask the registry for the resolver of the name.
+  // If that fails, the caller should pass --rpc to a Base RPC AND
+  // --resolver-address explicitly. The CLI does this lookup before
+  // calling rotateAgent so this branch shouldn't usually fire.
+  const { mainnet } = await import("viem/chains");
+  void mainnet;
+  void getOwner;
+  // Use ens-resolver-from-name pattern:
+  const ensClient = createPublicClient({
+    chain: { ...args.chain, id: 1 } as Chain,
+    transport: http(),
+  });
+  void ensClient;
+  void client;
+  throw new Error(
+    "rotateAgent: --resolver-address is required (CLI auto-resolves; library callers must pass)",
+  );
+}
+
+/**
+ * Read the persisted rotation artifact and extract its session-key
+ * address — used by the runtime adapter to locate the active session
+ * key after a rotation. The CLI also exposes this via the JSON output.
+ */
+export function readRotationArtifact(storeDir: string, alias: string, version: string): {
+  sessionKeyPath: string;
+  artifactName: string;
+} {
+  const artifactName = `${alias}-policy-${version}`;
+  const sessionKeyPath = join(storeDir, "session-keys", `${artifactName}.json`);
+  if (!existsSync(sessionKeyPath)) {
+    throw new Error(`rotation artifact not found: ${sessionKeyPath}`);
+  }
+  return { sessionKeyPath, artifactName };
+}

--- a/plans/ensemble-agent-rotate.md
+++ b/plans/ensemble-agent-rotate.md
@@ -1,0 +1,133 @@
+# Plan: `ensemble agent rotate <alias> --ens <ens-name>`
+
+PR #6 of the §7 roadmap. Last deploy-lifecycle primitive. Rotates the
+active session key + bumps the policy version on an ENS-bound agent.
+After this lands the lifecycle is `issue → pin → publish → verify →
+rotate`, all CLI-native, no bash anywhere.
+
+## Scope
+
+### In
+
+- New CLI subcommand `ensemble agent rotate <alias> --ens <ens-name>`
+- Library functions exported from `@synthesis/resolver`:
+  - `bumpPolicy(currentDoc, args)` — pure (no IO) — produces a v2+ doc
+    from a v1+ input, carries forward all non-rotated fields verbatim
+  - `nextMajorVersion(current)` — `"v1" → "v2"`, `"v1.2" → "v2"`
+  - `rotateAgent(args)` — orchestrates the 4 procedure steps via
+    composition over #49's `pinDirectory`, #51's `publishAgentRecords`,
+    and #53's `issueSessionKey`
+- Plan-only by default (`--broadcast` is the only mutation opt-in,
+  matches #51 convention)
+
+### Out (intentional)
+
+- **Onchain `revokeSessionKey` call** — not invoked. TRL semantic:
+  once `runtime-pubkey` no longer matches the old key, verifiers must
+  reject. On-chain revoke is gas the operator can pay later via a
+  `--revoke-onchain` follow-up flag.
+- **Owner-key rotation** — different ceremony (new keystore + new
+  smart-account + full re-issuance). Out of scope.
+- **Policy-semantic changes** — rotation only changes `version`,
+  `active-session-key.address`, `issued-at`, `ttl-hours`. Modifying
+  `delegators` / `scope` / `permitted-message-classes` is a separate
+  spec change.
+- **Site explorer route (#44)** — last remaining open issue after this
+  lands.
+
+## Decisions locked
+
+1. **Filename convention `<alias>-policy-v<N>.json` where N is the new
+   on-chain version** (Codex amendment 1). NOT a previous-suffix
+   counter. Filesystem layout mirrors published state. The
+   `RotateResult` field is named `newSessionKeyArtifact` (not
+   `newAlias` — disambiguates from the issue-side base alias).
+2. **Same env-var convention as `agent publish` (#51)**: `ENS_PRIVATE_KEY`
+   for non-Ledger signing, `--ledger` for hardware-wallet path. No
+   forked env-var name. Wallet-security note: project signer is the
+   manager EOA `0xeb0A…022`, not estmcmxci.eth — see
+   `synthesis-wallet-security.md` memory.
+3. **Live acceptance must include a `--broadcast` rotation** (Codex
+   amendment 3). Plan-only is insufficient because step 4 of the
+   procedure (multicall publish) goes unverified. Throwaway agent on a
+   fresh ENS name is the preferred target.
+4. **`bumpPolicy` is pure** (Codex amendment 4). Caller passes
+   `issuedAt` explicitly — no module-eval `Date.now()`. A purity test
+   asserts byte-identical JCS canonical bytes across two calls with
+   the same inputs.
+5. **No on-chain revoke** (Codex amendment 5). Documented in both the
+   issue and PR body. Belt-and-suspenders revoke is a follow-up flag.
+6. **`--broadcast` is the only mutation opt-in** (matches #51).
+   Regression test fences off `--dry-run`.
+
+## CLI surface
+
+```
+ensemble agent rotate <alias> --ens <ens-name>                                # plan-only
+ensemble agent rotate <alias> --ens <ens-name> --broadcast                     # send
+ensemble agent rotate <alias> --ens <ens-name> --policy-version v3             # explicit bump
+ensemble agent rotate <alias> --ens <ens-name> --ttl-hours 24                  # short-lived
+ensemble agent rotate <alias> --ens <ens-name> --rpc <alchemy>                 # required for SDK
+ensemble agent rotate <alias> --ens <ens-name> --ipfs-gateway <url>            # repeatable
+ensemble agent rotate <alias> --ens <ens-name> --ledger                        # hardware-wallet sign
+ensemble agent rotate <alias> --ens <ens-name> --format json
+```
+
+Env: `SYNTHESIS_KEYSTORE_PASSWORD` (always — owner key decrypt),
+`PINATA_JWT` (always — pin the new policy doc), `ENS_PRIVATE_KEY` (only
+for `--broadcast`, OR `--ledger`).
+
+Exit codes: 0 success, 1 SDK/IO/broadcast failure, 2 missing env or
+invalid input.
+
+## Output shape (locked)
+
+```ts
+interface RotateResult {
+  ensName: string;
+  alias: string;                   // base alias passed by operator
+  newSessionKeyArtifact: string;   // e.g. "alpha-policy-v2"
+  fromVersion: string;             // read from on-chain
+  toVersion: string;
+  fromRuntimePubkey: string;
+  toRuntimePubkey: string;
+  newPolicy: { hash: string; uri: string; version: string };
+  publishPlan: PublishPlan;        // re-uses #51's shape; 4 records changed
+  broadcast: boolean;
+}
+```
+
+## Files
+
+| File | Status |
+|---|---|
+| `packages/resolver/src/wallets/policy-bump.ts` | new — `bumpPolicy` + `nextMajorVersion` |
+| `packages/resolver/src/wallets/policy-bump.test.ts` | new — 11 tests including the purity fence |
+| `packages/resolver/src/wallets/rotate.ts` | new — `rotateAgent` orchestrator |
+| `packages/resolver/src/wallets/rotate.test.ts` | new — 9 tests (mocked SDK + IPFS + pin + publish) |
+| `packages/resolver/src/index.ts` | edit — re-export |
+| `packages/cli/commands/agent-rotate.ts` | new — CLI presenter |
+| `packages/cli/commands/agent-rotate.test.ts` | new — 6 tests including env-var locks + filename-convention fence |
+| `packages/cli/commands/index.ts`, `packages/cli/index.ts` | edit |
+| `plans/ensemble-agent-rotate.md` | new |
+
+LOC: ~1100.
+
+## Acceptance
+
+```bash
+pnpm install && pnpm -r build && pnpm -r test
+SYNTHESIS_KEYSTORE_PASSWORD=... PINATA_JWT=... \
+  node packages/cli/dist/index.js agent rotate <alias> --ens <ens-name> \
+       --rpc <alchemy-base>
+# plan-only: prints version-bump diff + 4-record multicall plan
+
+SYNTHESIS_KEYSTORE_PASSWORD=... PINATA_JWT=... ENS_PRIVATE_KEY=... \
+  node packages/cli/dist/index.js agent rotate <alias> --ens <ens-name> \
+       --rpc <alchemy-base> --broadcast
+# broadcasts; verifies via `agent verify <ens-name>` post-receipt
+```
+
+End-to-end live transcript on a throwaway agent (fresh ENS name) gets
+captured in the PR body: `issue → pin → publish → verify → rotate
+--broadcast → verify` proves the full lifecycle.


### PR DESCRIPTION
## Summary

- New CLI subcommand `ensemble agent rotate <alias> --ens <ens-name>` and library functions (`bumpPolicy`, `nextMajorVersion`, `rotateAgent`) exported from `@synthesis/resolver`.
- **Closes the deploy lifecycle.** After this lands: `issue → pin → publish → verify → rotate`, all CLI-native, no bash anywhere. Original "Ensemble-CLI-as-deploy-tool" goal from the operator-side plan doc.
- Composition over PR #49 (`agent pin`), #51 (`agent publish`), #53 (`agent issue`). Net-new code is `bumpPolicy` (pure policy-doc bump) + `rotateAgent` (orchestrator).
- Closes #54.

## Five amendments locked in advance

1. **Filename convention `<alias>-policy-v<N>.json`** where N is the **new on-chain version** (NOT a previous-suffix counter). Filesystem mirrors published state. The `RotateResult` field is named `newSessionKeyArtifact`, not `newAlias`. A regression test in `agent-rotate.test.ts` fences off both decisions.
2. **Same env-var convention as `agent publish`** (#51). `ENS_PRIVATE_KEY` for non-Ledger signing, `--ledger` for hardware-wallet path. No forked env-var name. Wallet-security memory: project signer is the manager EOA `0xeb0ABB36…15022`, NOT estmcmxci.eth — a regression test asserts `agent-rotate.ts` references `ENS_PRIVATE_KEY` and never `OWNER_PRIVATE_KEY` / `SIGNER_PRIVATE_KEY` / `ROTATE_PRIVATE_KEY`.
3. **Live acceptance includes a `--broadcast` rotation** — plan-only is insufficient because step 4 of the procedure (multicall publish) goes unverified. **Plan-only transcript on `emilemarcelagustin.eth` is captured below.** Full `--broadcast` lifecycle on a throwaway agent is deferred — needs a fresh ENS name + funded EOA. Library broadcast path is unit-tested with mocked send.
4. **`bumpPolicy` is pure** — caller passes `issuedAt` explicitly. A purity test asserts byte-identical JCS canonical bytes across two calls with the same inputs. Catches accidental `Date.now()` at module-eval.
5. **No on-chain `revokeSessionKey`.** TRL semantic (runtime-pubkey no longer matching the old key) is sufficient for verification. Belt-and-suspenders revoke is a follow-up flag (`--revoke-onchain`), not a default.

## Live plan-only transcript (`emilemarcelagustin.eth`)

```
$ ensemble agent rotate alpha --ens emilemarcelagustin.eth --rpc <alchemy-base>

  Rotation Plan
  ─────────────
    ENS name           : emilemarcelagustin.eth
    Alias              : alpha → alpha-policy-v2
    Version bump       : v1 → v2
    runtime-pubkey     : 0x8973B689… → 0xBC85bd8A…
    new policy hash    : 0x58c6aa0c8756a8950df5ee8e1f7c5ee57ae0843d6254031bf86f518d2323783b
    new policy URI     : ipfs://bafybeidrlcsco7ew6kvryu5gpjwpjfmqqgg2e56p5frqw6bkxdqxqlqfeu/policies/delegation-policy-v2.json

  Publish (4 records changed, 5 carried forward)
  ────────────────────────────────────────────────
    · class                (unchanged)
    · schema               (unchanged)
    ● runtime-pubkey
      from: 0x8973B6897554017d208DBeE2Ef5Fb8Fb046A6aEB
        to: 0xBC85bd8AA580C0a43776173031e3a974BcDd220E
    · runtime-status       (unchanged)
    · kernel-wallet        (unchanged)
    · agent-endpoint[web]  (unchanged)
    ● delegation
      from: ipfs://bafybeicqnxyjsvro7ipmdhhzymtk5y2qbaudzmtgggllt7midikdxkmoxi/...
        to: ipfs://bafybeidrlcsco7ew6kvryu5gpjwpjfmqqgg2e56p5frqw6bkxdqxqlqfeu/...
    ● policy-hash
      from: 0x6f3878cb630f8d16e5f8eac858f8923d15d5475773c1205b97dab0b06b35c114
        to: 0x58c6aa0c8756a8950df5ee8e1f7c5ee57ae0843d6254031bf86f518d2323783b
    ● policy-version
      from: v1
        to: v2

  No --broadcast — multicall would be sent to 0xF29100983E058B709F3D539b0c765937B804AC15.
```

The 4-record diff is exactly what the rotation procedure prescribes: `runtime-pubkey` → fresh signer; `delegation` → new pinned CID; `policy-hash` → keccak256(JCS(bumped doc)); `policy-version` → bumped. The 5 carry-forward records (`class`, `schema`, `runtime-status`, `kernel-wallet`, `agent-endpoint[web]`) match what's currently on-chain — confirms `bumpPolicy` doesn't touch unrelated fields.

**Side effect of plan-only:** the rotation actually pinned to IPFS (real Pinata pin under `alpha-policy-v2`) and wrote `~/.synthesis/session-keys/alpha-policy-v2.json` to disk. The original `alpha.json` is preserved alongside for audit. Plan-only means "no ENS write," not "no SDK or pin call" — those are required to compute the diff.

## Mid-task fix called out

`rotateAgent`'s `readRecords` initially used `args.chain` (Base) for the public client used to fetch ENS text records. ENS lives on **mainnet**, not Base — the read returned empty, and the orchestrator refused with `name lacks an existing policy`. Live plan-only on `emilemarcelagustin.eth` (which clearly has all 9 records) caught this immediately.

Fix: separate `ensRpcUrl` parameter that defaults to `https://eth.drpc.org`. Both `readRecords` and the internal client passed to `publishAgentRecords` now use mainnet. Documented in `RotateAgentArgs.ensRpcUrl`'s doc comment + commit message.

## Files

| File | Status |
|---|---|
| `packages/resolver/src/wallets/policy-bump.ts` | new — `bumpPolicy` + `nextMajorVersion` |
| `packages/resolver/src/wallets/policy-bump.test.ts` | new — 11 tests including the purity fence |
| `packages/resolver/src/wallets/rotate.ts` | new — `rotateAgent` orchestrator |
| `packages/resolver/src/wallets/rotate.test.ts` | new — 9 tests (mocked SDK + IPFS + pin + publish) |
| `packages/resolver/src/index.ts` | edit — re-export |
| `packages/cli/commands/agent-rotate.ts` | new — CLI presenter |
| `packages/cli/commands/agent-rotate.test.ts` | new — 6 tests (env locks, filename lock, dry-run fence) |
| `packages/cli/commands/index.ts`, `packages/cli/index.ts` | edit |
| `plans/ensemble-agent-rotate.md` | new |

LOC: ~1508.

## Test plan

- [x] `pnpm -r test` — 115 resolver + 40 CLI tests pass offline
- [x] `pnpm -r build` — clean
- [x] `pnpm typecheck` — clean
- [x] Live plan-only on `emilemarcelagustin.eth` — output captured above; v1 → v2 bump, 4-record diff, no broadcast
- [x] On-disk artifacts — `~/.synthesis/session-keys/alpha-policy-v2.json` created with fresh `sessionKeyAddress` and matching `kernelWallet` (kernel deterministic across runs); original `alpha.json` preserved
- [ ] Live `--broadcast` — deferred. Library path mocked-send unit-tested. Mutates mainnet ENS state on `emilemarcelagustin.eth`; would also require coordinated runtime daemon restart (the Pinata container at `https://xxje1rfb.agents.pinata.cloud/app` would need its session-key blob updated). Captured as a follow-up artifact rather than gating PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)